### PR TITLE
Major edits on flowgraph, some refactoring on translator

### DIFF
--- a/src/main/java/translating/FlowGraph.java
+++ b/src/main/java/translating/FlowGraph.java
@@ -526,6 +526,10 @@ public class FlowGraph {
         public void setChildren(List<Block> children) {
             this.children = children;
         }
+        
+        public void removeLine(Stmt line) {
+            lines.remove(line);
+        }
 
         /**
          * A convenience method that returns the first line of this block.

--- a/src/main/java/translating/FlowGraph.java
+++ b/src/main/java/translating/FlowGraph.java
@@ -69,7 +69,7 @@ public class FlowGraph {
     /**
      * @return all lines of all blocks within this flow graph
      */
-    public List<Stmt> getViewOfLines() {
+    public List<Stmt> getLines() {
         List<Stmt> lines = new ArrayList<>();
         getBlocks().forEach(block -> lines.addAll(block.getLines()));
         return lines;
@@ -119,7 +119,7 @@ public class FlowGraph {
      * A complete traversal of a flow graph should encounter no line twice, or no line with the same PC twice.
      */
     private void enforceUniqueLines() {
-        List<Stmt> linesList = getViewOfLines();
+        List<Stmt> linesList = getLines();
         List<String> pcList = new ArrayList<>();
         linesList.forEach(line -> pcList.add(line.getLabel().getPc()));
         Set<Stmt> linesSet = new HashSet<>(linesList);

--- a/src/main/java/translating/FlowGraphVisualiser.java
+++ b/src/main/java/translating/FlowGraphVisualiser.java
@@ -46,12 +46,12 @@ public class FlowGraphVisualiser extends Application {
         FlowGraph flowGraph = FlowGraph.fromStmts(facts);
         Digraph<FlowGraph.Block, String> g = new DigraphEdgeList<>();
         for (FlowGraph.Function function : flowGraph.getFunctions()) {
-            for (FlowGraph.Block block : function.getRootBlock().getBlocksInCluster()) {
+            for (FlowGraph.Block block : function.getBlocks()) {
                 g.insertVertex(block);
             }
         }
         for (FlowGraph.Function function : flowGraph.getFunctions()) {
-            for (FlowGraph.Block block : function.getRootBlock().getBlocksInCluster()) {
+            for (FlowGraph.Block block : function.getBlocks()) {
                 for (FlowGraph.Block child : block.getChildren()) {
                     g.insertEdge(block, child, getEdgeId());
                 }

--- a/src/main/scala/vcgen/VCGen.scala
+++ b/src/main/scala/vcgen/VCGen.scala
@@ -12,7 +12,7 @@ object VCGen {
     flowGraph.setFunctions(flowGraph.getFunctions.asScala.map(func => {
       func
     }).asJava)
-    flowGraph.getViewOfLines.asScala.flatMap(line =>
+    flowGraph.getLines.asScala.flatMap(line =>
       List(line, Assert("-1", Literal("0")))
     ).toList
   }


### PR DESCRIPTION
- Functions in flow graphs now contain a list of all their blocks
- moved functionality for getting all blocks / all lines in a function to the Function class
- refactored BoogieTranslator to utilise setters instead of modifying lists returned by these aforementioned methods ^