### PR TITLE
Changed the ast to be mutable

### DIFF
--- a/src/main/scala/analysis/Analysis.scala
+++ b/src/main/scala/analysis/Analysis.scala
@@ -90,7 +90,8 @@ trait ValueAnalysisMisc:
       case r: CfgStatementNode =>
         r.data match
           // assignments
-          case LocalAssign(lhs: LocalVar, rhs: Expr, _, _) => s + (lhs -> eval(rhs, s))
+          // changed the class comparison to the actual class because of removal of case class (no unapply function needed for below now)
+          case la: LocalAssign => s + (la.lhs -> eval(la.rhs, s))
 
           // all others: like no-ops
           case _ => s

--- a/src/main/scala/analysis/Cfg.scala
+++ b/src/main/scala/analysis/Cfg.scala
@@ -159,11 +159,13 @@ object Cfg:
     def generateCfgStatement(stmt: Statement): Cfg =
       val node = CfgStatementNode(data = stmt)
 
+      // TODO: commented out the GoTo case because it is not supported yet and it was causing an error when the ast was
+      // made mutable (ie. case class -> class)
       stmt match
-        case GoTo(target, condition, _, _) =>
-          blocks.get(target) match
-            case Some(blockNode) => node.addEdge(blockNode)
-            case _               =>
+//        case GoTo(target, condition, _, _) =>
+//          blocks.get(target) match
+//            case Some(blockNode) => node.addEdge(blockNode)
+//            case _               =>
         case _ =>
 
       singletonGraph(node)

--- a/src/main/scala/astnodes/Expr.scala
+++ b/src/main/scala/astnodes/Expr.scala
@@ -40,7 +40,7 @@ trait Expr {
 
 /** Concatenation of two bitvectors
   */
-case class Concat(left: Expr, right: Expr) extends Expr {
+class Concat(var left: Expr, var right: Expr) extends Expr {
   override def toBoogie: BinaryBExpr = BinaryBExpr(BVCONCAT, left.toBoogie, right.toBoogie)
 
   override def size: Int = left.size + right.size
@@ -60,7 +60,7 @@ case class Concat(left: Expr, right: Expr) extends Expr {
 /** Signed extend - extend in BIL
   */
 
-case class SignedExtend(width: Int, body: Expr) extends Expr {
+class SignedExtend(var width: Int, var body: Expr) extends Expr {
   //override def toString: String = String.format("%s[%d:%d]", body, high, low)
   override def locals: Set[LocalVar] = body.locals
   //override def subst(v: Variable, w: Variable): Expr = copy(body = body.subst(v, w))
@@ -89,7 +89,7 @@ case class SignedExtend(width: Int, body: Expr) extends Expr {
 /** Unsigned extend - pad in BIL
   */
 
-case class UnsignedExtend(width: Int, body: Expr) extends Expr {
+class UnsignedExtend(var width: Int, var body: Expr) extends Expr {
   //override def toString: String = String.format("%s[%d:%d]", body, high, low)
   override def locals: Set[LocalVar] = body.locals
   //override def subst(v: Variable, w: Variable): Expr = copy(body = body.subst(v, w))
@@ -117,7 +117,7 @@ case class UnsignedExtend(width: Int, body: Expr) extends Expr {
 
 /** Extracts the bits from firstInt to secondInt (inclusive) from variable.
   */
-case class Extract(high: Int, low: Int, body: Expr) extends Expr {
+class Extract(var high: Int, var low: Int, var body: Expr) extends Expr {
   override def toString: String = String.format("%s[%d:%d]", body, high, low)
   override def locals: Set[LocalVar] = body.locals
 
@@ -162,7 +162,7 @@ case object LowCast {
 
 /** Literal expression (e.g. 4, 5, 10)
   */
-case class Literal(value: BigInt, size: Int) extends Expr {
+class Literal(var value: BigInt, var size: Int) extends Expr {
 
   /** Value of literal */
   override def toString: String = s"${value}bv$size"
@@ -177,7 +177,7 @@ case class Literal(value: BigInt, size: Int) extends Expr {
 
 /** Unary operator
   */
-case class UnOp(operator: UnOperator, exp: Expr) extends Expr {
+class UnOp(var operator: UnOperator, var exp: Expr) extends Expr {
   //override def subst(v: Variable, w: Variable): Expr = copy(exp = exp.subst(v, w))
   //override def simplify(old: Expr, sub: Expr): Expr = SimplificationUtil.uniArithmetic(copy(exp = exp.simplify(old, sub)))
 
@@ -207,7 +207,7 @@ object UnOperator {
 
 /** Binary operation of two expressions
   */
-case class BinOp(operator: BinOperator, lhs: Expr, rhs: Expr) extends Expr {
+class BinOp(var operator: BinOperator, var lhs: Expr, var rhs: Expr) extends Expr {
   //override def subst(v: Variable, w: Variable): Expr = {
   //  copy(lhs = lhs.subst(v, w), rhs = rhs.subst(v, w))
   //}
@@ -317,7 +317,7 @@ trait Variable extends Expr {
   //def toGamma: SecVar | SecMemLoad
 }
 
-case class LocalVar(name: String, override val size: Int) extends Variable {
+class LocalVar(var name: String, override val size: Int) extends Variable {
   override def toString: String = name
   override def locals: Set[LocalVar] = Set(this)
   override def gammas: Set[Variable] = Set(this)
@@ -328,7 +328,7 @@ case class LocalVar(name: String, override val size: Int) extends Variable {
 
 /** A load from memory at location exp
   */
-case class MemAccess(memory: Memory, index: Expr, endian: Endian, override val size: Int) extends Variable {
+class MemAccess(var memory: Memory, var index: Expr, var endian: Endian, override val size: Int) extends Variable {
   override def toString: String = s"${memory.name}[$index]"
   override def locals: Set[LocalVar] = index.locals
   override def toBoogie: MemoryLoad = MemoryLoad(memory.toBoogie, index.toBoogie, endian, size)
@@ -390,16 +390,19 @@ object MemAccess {
   }
 }
 
-case class Memory(name: String, addressSize: Int, valueSize: Int) extends Variable {
+case class Memory(var name: String, var addressSize: Int, var valueSize: Int) extends Variable {
   override def size: Int = valueSize // should reconsider
   //override def subst(v: Variable, w: Variable): Expr = ???
   override def locals: Set[LocalVar] = Set()
   override def gammas: Set[Variable] = Set()
   override def toBoogie: MapVar = MapVar(name, MapType(BitVec(addressSize), BitVec(valueSize)), Scope.Global)
   override def toGamma: MapVar = MapVar(s"Gamma_$name", MapType(BitVec(addressSize), BoolType), Scope.Global)
+  def copy(name: String = this.name, addressSize: Int = this.addressSize, valueSize: Int = this.valueSize): Memory = {
+    Memory(name, addressSize, valueSize)
+  }
 }
 
-case class Store(memory: Memory, index: Expr, value: Expr, endian: Endian, size: Int) extends Expr {
+class Store(var memory: Memory, var index: Expr, var value: Expr, var endian: Endian, var size: Int) extends Expr {
   //override def subst(v: Variable, w: Variable): Expr = ???
   override def locals: Set[LocalVar] = index.locals ++ value.locals
   override def gammas: Set[Variable] = Set()

--- a/src/main/scala/astnodes/Expr.scala
+++ b/src/main/scala/astnodes/Expr.scala
@@ -7,10 +7,6 @@ import util.AssumptionViolationException
 /** Expression
   */
 trait Expr {
-
-  /* Substitute a given variable for another variable */
-  //def subst(v: Variable, w: Variable): Expr
-
   def toBoogie: BExpr
   def toGamma: BExpr = {
     val gammaVars: Set[BExpr] = gammas.map(_.toGamma)
@@ -24,9 +20,6 @@ trait Expr {
       }
     }
   }
-  //def toBoogieString: String = toString
-
-  //def simplify(old: Expr, sub: Expr): Expr
   /*
    * The size of output of the given expression.
    *
@@ -46,26 +39,13 @@ class Concat(var left: Expr, var right: Expr) extends Expr {
   override def size: Int = left.size + right.size
   override def gammas: Set[Variable] = left.gammas ++ right.gammas
   override def locals: Set[LocalVar] = left.locals ++ right.locals
-  //override def subst(v: Variable, w: Variable): Expr = {
-  //  copy(left = left.subst(v, w), right = right.subst(v, w))
-  //}
-
-  /*
-  override def simplify(old: Expr, sub: Expr): Expr = {
-    SimplificationUtil.bitvecConcat(copy(left = left.simplify(old,sub), right = right.simplify(old,sub)))
-  }
-   */
 }
 
 /** Signed extend - extend in BIL
   */
 
 class SignedExtend(var width: Int, var body: Expr) extends Expr {
-  //override def toString: String = String.format("%s[%d:%d]", body, high, low)
   override def locals: Set[LocalVar] = body.locals
-  //override def subst(v: Variable, w: Variable): Expr = copy(body = body.subst(v, w))
-  //override def simplify(old: Expr, sub: Expr): Expr = ???
-
   override def size: Int = width
 
   override def toBoogie: BExpr = {
@@ -121,12 +101,6 @@ class Extract(var high: Int, var low: Int, var body: Expr) extends Expr {
   override def toString: String = String.format("%s[%d:%d]", body, high, low)
   override def locals: Set[LocalVar] = body.locals
 
-  //override def subst(v: Variable, w: Variable): Expr = this.copy(body = body.subst(v, w))
-
-  /*
-  override def simplify(old: Expr, sub: Expr): Expr =
-    SimplificationUtil.bitvecExtract(copy(body = body.simplify(old, sub)))
-   */
   // + 1 as extracts are inclusive (e.g. [31:0] has 32 bits)
   override val size: Int = high - low + 1
 
@@ -162,15 +136,12 @@ case object LowCast {
 
 /** Literal expression (e.g. 4, 5, 10)
   */
-class Literal(var value: BigInt, var size: Int) extends Expr {
+case class Literal(value: BigInt, size: Int) extends Expr {
 
   /** Value of literal */
   override def toString: String = s"${value}bv$size"
 
   override def locals: Set[LocalVar] = Set()
-  //override def subst(v: Variable, w: Variable): Expr = this
-  //override def simplify(old: Expr, sub: Expr): Expr = this
-
   override def toBoogie: BitVecLiteral = BitVecLiteral(value, size)
   override def gammas: Set[Variable] = Set()
 }
@@ -178,9 +149,6 @@ class Literal(var value: BigInt, var size: Int) extends Expr {
 /** Unary operator
   */
 class UnOp(var operator: UnOperator, var exp: Expr) extends Expr {
-  //override def subst(v: Variable, w: Variable): Expr = copy(exp = exp.subst(v, w))
-  //override def simplify(old: Expr, sub: Expr): Expr = SimplificationUtil.uniArithmetic(copy(exp = exp.simplify(old, sub)))
-
   override def locals: Set[LocalVar] = exp.locals
   override def size: Int = exp.size
 
@@ -208,14 +176,6 @@ object UnOperator {
 /** Binary operation of two expressions
   */
 class BinOp(var operator: BinOperator, var lhs: Expr, var rhs: Expr) extends Expr {
-  //override def subst(v: Variable, w: Variable): Expr = {
-  //  copy(lhs = lhs.subst(v, w), rhs = rhs.subst(v, w))
-  //}
-
-  /* override def simplify(old: Expr, sub: Expr): Expr = {
-    SimplificationUtil.binArithmetic(copy(lhs = lhs.simplify(old,sub), rhs = rhs.simplify(old, sub)))
-  } */
-
   override def locals: Set[LocalVar] = lhs.locals ++ rhs.locals
   override def gammas: Set[Variable] = lhs.gammas ++ rhs.gammas
 
@@ -312,23 +272,19 @@ case object LE extends BinOperator("LE")
 case object SLT extends BinOperator("SLT")
 case object SLE extends BinOperator("SLE")
 
-trait Variable extends Expr {
-  //override def subst(v: Variable, w: Variable): Variable = if (v == this) w else this
-  //def toGamma: SecVar | SecMemLoad
-}
+trait Variable extends Expr
 
-class LocalVar(var name: String, override val size: Int) extends Variable {
+case class LocalVar(name: String, override val size: Int) extends Variable {
   override def toString: String = name
   override def locals: Set[LocalVar] = Set(this)
   override def gammas: Set[Variable] = Set(this)
   override def toGamma: BVar = BVariable(s"Gamma_$name", BoolType, Scope.Local)
   override def toBoogie: BVar = BVariable(s"$name", BitVec(size), Scope.Local)
-  //override def simplify(old: Expr, sub: Expr): Expr = if (old == this) sub else this
 }
 
 /** A load from memory at location exp
   */
-class MemAccess(var memory: Memory, var index: Expr, var endian: Endian, override val size: Int) extends Variable {
+class MemAccess(var memory: Memory, var index: Expr, var endian: Endian, var size: Int) extends Variable {
   override def toString: String = s"${memory.name}[$index]"
   override def locals: Set[LocalVar] = index.locals
   override def toBoogie: MemoryLoad = MemoryLoad(memory.toBoogie, index.toBoogie, endian, size)
@@ -342,41 +298,6 @@ class MemAccess(var memory: Memory, var index: Expr, var endian: Endian, overrid
       L(memory.toBoogie, index.toBoogie)
     )
   }
-
-  /*
-  override def simplify(old: Expr, sub: Expr): Expr = {
-    if (!onStack) copy(index = index.simplify(old, sub))
-    else if (onStack && old == this) sub
-    else this
-  }
-   */
-
-  //def toL: SecMemLoad = SecMemLoad(false, true, index)
-  //override def toGamma: SecMemLoad = SecMemLoad(true, false, index)
-
-  /*
-  def boogieAccesses: Seq[MapAccess] = {
-    val boogieMap = memory.toBoogie
-    val boogieIndex = index.toBoogie
-    val accesses = for (i <- 0 until (size / memory.valueSize)) yield {
-      if (i == 0) {
-        MapAccess(boogieMap, boogieIndex)
-      } else {
-        MapAccess(boogieMap, BinaryBExpr(BVADD, index.toBoogie, BitVecLiteral(i, memory.addressSize)))
-      }
-    }
-    endian match {
-      case Endian.BigEndian    => accesses.reverse
-      case Endian.LittleEndian => accesses
-    }
-  }
-
-  override def toBoogie: BExpr = {
-    boogieAccesses.tail.foldLeft(boogieAccesses.head) { (concat: BExpr, next: MapAccess) =>
-      BinaryBExpr(BVCONCAT, next, concat)
-    }
-  }
-   */
 }
 
 object MemAccess {
@@ -390,26 +311,20 @@ object MemAccess {
   }
 }
 
-case class Memory(var name: String, var addressSize: Int, var valueSize: Int) extends Variable {
+case class Memory(name: String, addressSize: Int, valueSize: Int) extends Variable {
   override def size: Int = valueSize // should reconsider
-  //override def subst(v: Variable, w: Variable): Expr = ???
   override def locals: Set[LocalVar] = Set()
   override def gammas: Set[Variable] = Set()
   override def toBoogie: MapVar = MapVar(name, MapType(BitVec(addressSize), BitVec(valueSize)), Scope.Global)
   override def toGamma: MapVar = MapVar(s"Gamma_$name", MapType(BitVec(addressSize), BoolType), Scope.Global)
-  def copy(name: String = this.name, addressSize: Int = this.addressSize, valueSize: Int = this.valueSize): Memory = {
-    Memory(name, addressSize, valueSize)
-  }
 }
 
 class Store(var memory: Memory, var index: Expr, var value: Expr, var endian: Endian, var size: Int) extends Expr {
-  //override def subst(v: Variable, w: Variable): Expr = ???
   override def locals: Set[LocalVar] = index.locals ++ value.locals
   override def gammas: Set[Variable] = Set()
   override def toBoogie: MemoryStore = MemoryStore(memory.toBoogie, index.toBoogie, value.toBoogie, endian, size)
   override def toGamma: GammaStore =
     GammaStore(memory.toGamma, index.toBoogie, value.toGamma, size, size / memory.valueSize)
-  //def toBoogieProc: String
 }
 
 object Store {

--- a/src/main/scala/astnodes/Program.scala
+++ b/src/main/scala/astnodes/Program.scala
@@ -14,41 +14,28 @@ globals
 
 class Program(var functions: List[Subroutine]) {
   override def toString: String = functions.mkString("\n")
-  //def toBoogieString: String = functions.map(_.toBoogieString).mkString("\n")
 
   def getFunction(name: String): Option[Subroutine] = {
-    functions.find(f => f.name == name).map(_.copy(blocks = List()))
+    functions.find(f => f.name == name)
   }
 
   def getFunction(address: Int): Option[Subroutine] = {
-    functions.find(f => f.address == address).map(_.copy(blocks = List()))
-  }
-
-  def copy(functions: List[Subroutine] = functions): Program = {
-    new Program(functions)
+    functions.find(f => f.address == address)
   }
 }
 
 class Subroutine(var name: String, var address: Int, var blocks: List[Block], var in: List[Parameter], var out: List[Parameter]) {
   override def toString: String = name + " " + address + " " + in + " " + out + "[\n" + blocks.mkString("\n") + "\n]"
-  //def toBoogieString: String = "procedure " + name + "(" + in.map(_.toBoogieString).mkString(", ") + ") returns (" + out.map(_.toBoogieString).mkString(", ") + ") {\n  " +
-  //  blocks.map(_.toBoogieString).mkString("\n  ") + "\n\n}"
 
   def calls: Set[String] = blocks.flatMap(b => b.calls).toSet
 
   def getBlock(label: String): Option[Block] = {
     blocks.find(b => b.label == label)
   }
-
-  def copy(name: String = this.name, address: Int = this.address, blocks: List[Block] = this.blocks, in: List[Parameter] = this.in, out: List[Parameter] = this.out): Subroutine = {
-    new Subroutine(name, address, blocks, in, out)
-  }
 }
 
 class Block(var label: String, var address: Option[Int], var statements: List[Statement]) {
   override def toString: String = label + " " + address + "\n" + statements.mkString("\n")
-  //def toBoogieString: String = label + ":\n    " + instructions.flatMap(_.statements).map(_.toBoogieString).mkString("\n    ")
-
   def modifies: Set[Memory] = statements.flatMap(_.modifies).toSet
 
   def locals: Set[LocalVar] = statements.flatMap(_.locals).toSet
@@ -58,5 +45,4 @@ class Block(var label: String, var address: Option[Int], var statements: List[St
 
 class Parameter(var name: String, var size: Int, var value: LocalVar) {
   def toBoogie: List[BVariable] = List(BParam(name, BitVec(size)), BParam(s"Gamma_$name", BoolType))
-  // def toBoogieString: String = name + ": bv" + size
 }

--- a/src/main/scala/astnodes/Program.scala
+++ b/src/main/scala/astnodes/Program.scala
@@ -12,7 +12,7 @@ security predicates
 globals
  */
 
-case class Program(functions: List[Subroutine]) {
+class Program(var functions: List[Subroutine]) {
   override def toString: String = functions.mkString("\n")
   //def toBoogieString: String = functions.map(_.toBoogieString).mkString("\n")
 
@@ -23,9 +23,13 @@ case class Program(functions: List[Subroutine]) {
   def getFunction(address: Int): Option[Subroutine] = {
     functions.find(f => f.address == address).map(_.copy(blocks = List()))
   }
+
+  def copy(functions: List[Subroutine] = functions): Program = {
+    new Program(functions)
+  }
 }
 
-case class Subroutine(name: String, address: Int, blocks: List[Block], in: List[Parameter], out: List[Parameter]) {
+class Subroutine(var name: String, var address: Int, var blocks: List[Block], var in: List[Parameter], var out: List[Parameter]) {
   override def toString: String = name + " " + address + " " + in + " " + out + "[\n" + blocks.mkString("\n") + "\n]"
   //def toBoogieString: String = "procedure " + name + "(" + in.map(_.toBoogieString).mkString(", ") + ") returns (" + out.map(_.toBoogieString).mkString(", ") + ") {\n  " +
   //  blocks.map(_.toBoogieString).mkString("\n  ") + "\n\n}"
@@ -35,9 +39,13 @@ case class Subroutine(name: String, address: Int, blocks: List[Block], in: List[
   def getBlock(label: String): Option[Block] = {
     blocks.find(b => b.label == label)
   }
+
+  def copy(name: String = this.name, address: Int = this.address, blocks: List[Block] = this.blocks, in: List[Parameter] = this.in, out: List[Parameter] = this.out): Subroutine = {
+    new Subroutine(name, address, blocks, in, out)
+  }
 }
 
-case class Block(label: String, address: Option[Int], statements: List[Statement]) {
+class Block(var label: String, var address: Option[Int], var statements: List[Statement]) {
   override def toString: String = label + " " + address + "\n" + statements.mkString("\n")
   //def toBoogieString: String = label + ":\n    " + instructions.flatMap(_.statements).map(_.toBoogieString).mkString("\n    ")
 
@@ -48,7 +56,7 @@ case class Block(label: String, address: Option[Int], statements: List[Statement
 
 }
 
-case class Parameter(name: String, size: Int, value: LocalVar) {
+class Parameter(var name: String, var size: Int, var value: LocalVar) {
   def toBoogie: List[BVariable] = List(BParam(name, BitVec(size)), BParam(s"Gamma_$name", BoolType))
   // def toBoogieString: String = name + ": bv" + size
 }

--- a/src/main/scala/astnodes/Statement.scala
+++ b/src/main/scala/astnodes/Statement.scala
@@ -2,142 +2,41 @@ package astnodes
 import boogie._
 
 trait Statement {
-  //def subst(v: Variable, w: Variable): Stmt
-
-  //def toBoogieString: String = toString
   def modifies: Set[Memory] = Set()
   def locals: Set[LocalVar] = Set()
   def calls: Set[String] = Set() // names of functions called by this statement
-
-  /*
-  def labelString: String = if (labelVisible) {
-    "label" + pc + ": "
-  } else {
-    ""
-  }
-   */
-
-  //def withVisibleLabel: Stmt
 }
 
 class DirectCall(var target: String, var condition: Expr, var returnTarget: Option[String], var line: String, var instruction: String) extends Statement {
-  /*
-  override def toBoogieString: String = {
-    if (condition == Literal(BigInt(1), 1)) {
-      noCondition
-    } else {
-      "if (" + condition.toBoogieString + " == 0bv1) {\n      " + noCondition + "\n    }"
-    }
-  }
-  def noCondition: String = "call " + target + "(); // with return " + returnTarget.getOrElse("none")
-   */
-
   override def calls: Set[String] = Set(target)
   override def locals: Set[LocalVar] = condition.locals
 }
 
 class IntrinsicCall(var target: String, var condition: Expr, var returnTarget: Option[String], var line: String, var instruction: String) extends Statement {
-
   override def calls: Set[String] = Set(target)
   override def locals: Set[LocalVar] = condition.locals
 }
 
 class IndirectCall(var target: LocalVar, var condition: Expr, var returnTarget: Option[String], var line: String, var instruction: String) extends Statement {
-  /*
-  override def toBoogieString: String = {
-    if (condition == Literal(BigInt(1), 1)) {
-      noCondition
-    } else {
-      "if (" + condition.toBoogieString + " == 0bv1) {\n      " + noCondition + "\n    }"
-    }
-  }
-  def noCondition: String = "call " + target.toBoogieString + "; // with return " + returnTarget.getOrElse("none")
-   */
-
   override def locals: Set[LocalVar] = condition.locals + target
 }
 
 class GoTo(var target: String, var condition: Expr, var line: String, var instruction: String) extends Statement {
-  /*
-  override def toBoogieString: String = {
-    if (condition == Literal(BigInt(1), 1)) {
-      noCondition
-    } else {
-      "if (" + condition.toBoogieString + " == 0bv1) {\n      " + noCondition + "\n    }"
-    }
-  }
-  def noCondition: String = "goto " + target + ";"
-   */
-
   override def locals: Set[LocalVar] = condition.locals
 }
 
 class Skip(var line: String, var instruction: String) extends Statement {
   override def toString: String = "skip;"
-  //override def subst(v: Variable, w: Variable): Stmt = this
-
-  //override def withVisibleLabel: Stmt = copy(labelVisible = true)
-
 }
 
 trait Assign(lhs: Variable, rhs: Expr, line: String, instruction: String) extends Statement {
   override def toString: String = String.format("%s := %s;", lhs, rhs)
-
-  /*
-  override def subst(v: Variable, w: Variable): Stmt = lhs.subst(v,w) match {
-    case lhsRes: MemLoad => MemAssign(pc, lhsRes, rhs.subst(v,w))
-    case lhsRes: Register => RegisterAssign(pc, lhsRes, rhs = rhs.subst(v,w))
-  }
-   */
-
-  // this would be nicer to have per type instead
-  /*
-  def simplify(oldExpr: Expr, newExpr: Expr): AssignStatement = {
-    lhs match {
-      case lhsRes: MemAccess =>
-        val newLhs = if (!lhsRes.onStack) {
-          lhsRes.simplify(oldExpr, newExpr).asInstanceOf[MemAccess]
-        } else {
-          lhsRes
-        }
-        MemAssign(newLhs, rhs.simplify(oldExpr, newExpr))
-      case lhsRes: LocalVar => LocalAssign(lhsRes, rhs.simplify(oldExpr, newExpr))
-      case _ => this
-    }
-  }
-   */
 }
-
-/*
-case class GammaUpdate (lhs: SecVar | SecMemLoad, sec: Sec) extends Statement {
-
-  override def toBoogieString: String = s"${lhs.toString} := ${sec.toString};"
-
-  override def modifies: Set[Memory] = Set()
-  override def locals: Set[LocalVar] = Set()
-
-  // TODO
-  //override def subst(v: Variable, w: Variable): Stmt = this
-}
- */
 
 /** Memory store
   */
 class MemAssign(var lhs: Memory, var rhs: Store, var line: String, var instruction: String) extends Assign(lhs, rhs, line, instruction) {
-
-  //override def toBoogieString: String = s"${lhs.toBoogieString} := ${rhs.toBoogieString};"
-  /*
-  def lhsToString(exp: Expr) = s"heap[${exp.toBoogieString}]"
-
-  override def toBoogieString: String = {
-    (0 until lhs.size / 8).map(n => {
-      s"heap[${lhs.index.toBoogieString} + $n] := ${Extract(8 * (n + 1) - 1, 8 * n, rhs).toBoogieString}"
-    }).mkString("; ") + s";"
-  }
-   */
-
   override def modifies: Set[Memory] = Set(lhs)
-
   override def locals: Set[LocalVar] = rhs.locals
 }
 
@@ -152,16 +51,5 @@ object MemAssign {
 }
 
 class LocalAssign(var lhs: LocalVar, var rhs: Expr, var line: String, var instruction: String) extends Assign(lhs, rhs, line, instruction) {
-  //override def toBoogieString: String = s"${lhs.toBoogieString} := ${rhs.toBoogieString};"
-
-  // Otherwise is flag (e.g. #1)
-  /*
-  def isRegister: Boolean = lhs.name.charAt(0) == 'R'
-
-  def isStackPointer: Boolean = this.isRegister && lhs.name.substring(1).equals("31")
-  def isFramePointer: Boolean = this.isRegister && lhs.name.substring(1).equals("29")
-  def isLinkRegister: Boolean = this.isRegister && lhs.name.substring(1).equals("30")
-   */
   override def locals: Set[LocalVar] = rhs.locals + lhs
-
 }

--- a/src/main/scala/astnodes/Statement.scala
+++ b/src/main/scala/astnodes/Statement.scala
@@ -20,7 +20,7 @@ trait Statement {
   //def withVisibleLabel: Stmt
 }
 
-case class DirectCall(target: String, condition: Expr, returnTarget: Option[String], line: String, instruction: String) extends Statement {
+class DirectCall(var target: String, var condition: Expr, var returnTarget: Option[String], var line: String, var instruction: String) extends Statement {
   /*
   override def toBoogieString: String = {
     if (condition == Literal(BigInt(1), 1)) {
@@ -36,13 +36,13 @@ case class DirectCall(target: String, condition: Expr, returnTarget: Option[Stri
   override def locals: Set[LocalVar] = condition.locals
 }
 
-case class IntrinsicCall(target: String, condition: Expr, returnTarget: Option[String], line: String, instruction: String) extends Statement {
+class IntrinsicCall(var target: String, var condition: Expr, var returnTarget: Option[String], var line: String, var instruction: String) extends Statement {
 
   override def calls: Set[String] = Set(target)
   override def locals: Set[LocalVar] = condition.locals
 }
 
-case class IndirectCall(target: LocalVar, condition: Expr, returnTarget: Option[String], line: String, instruction: String) extends Statement {
+class IndirectCall(var target: LocalVar, var condition: Expr, var returnTarget: Option[String], var line: String, var instruction: String) extends Statement {
   /*
   override def toBoogieString: String = {
     if (condition == Literal(BigInt(1), 1)) {
@@ -57,7 +57,7 @@ case class IndirectCall(target: LocalVar, condition: Expr, returnTarget: Option[
   override def locals: Set[LocalVar] = condition.locals + target
 }
 
-case class GoTo(target: String, condition: Expr, line: String, instruction: String) extends Statement {
+class GoTo(var target: String, var condition: Expr, var line: String, var instruction: String) extends Statement {
   /*
   override def toBoogieString: String = {
     if (condition == Literal(BigInt(1), 1)) {
@@ -72,7 +72,7 @@ case class GoTo(target: String, condition: Expr, line: String, instruction: Stri
   override def locals: Set[LocalVar] = condition.locals
 }
 
-case class Skip(line: String, instruction: String) extends Statement {
+class Skip(var line: String, var instruction: String) extends Statement {
   override def toString: String = "skip;"
   //override def subst(v: Variable, w: Variable): Stmt = this
 
@@ -123,7 +123,7 @@ case class GammaUpdate (lhs: SecVar | SecMemLoad, sec: Sec) extends Statement {
 
 /** Memory store
   */
-case class MemAssign(lhs: Memory, rhs: Store, line: String, instruction: String) extends Assign(lhs, rhs, line, instruction) {
+class MemAssign(var lhs: Memory, var rhs: Store, var line: String, var instruction: String) extends Assign(lhs, rhs, line, instruction) {
 
   //override def toBoogieString: String = s"${lhs.toBoogieString} := ${rhs.toBoogieString};"
   /*
@@ -151,7 +151,7 @@ object MemAssign {
   }
 }
 
-case class LocalAssign(lhs: LocalVar, rhs: Expr, line: String, instruction: String) extends Assign(lhs, rhs, line, instruction) {
+class LocalAssign(var lhs: LocalVar, var rhs: Expr, var line: String, var instruction: String) extends Assign(lhs, rhs, line, instruction) {
   //override def toBoogieString: String = s"${lhs.toBoogieString} := ${rhs.toBoogieString};"
 
   // Otherwise is flag (e.g. #1)
@@ -163,4 +163,5 @@ case class LocalAssign(lhs: LocalVar, rhs: Expr, line: String, instruction: Stri
   def isLinkRegister: Boolean = this.isRegister && lhs.name.substring(1).equals("30")
    */
   override def locals: Set[LocalVar] = rhs.locals + lhs
+
 }

--- a/src/main/scala/translating/BoogieTranslator.scala
+++ b/src/main/scala/translating/BoogieTranslator.scala
@@ -6,7 +6,7 @@ import specification.*
 
 import scala.language.postfixOps
 
-case class BoogieTranslator(program: Program, spec: Specification) {
+class BoogieTranslator(var program: Program, var spec: Specification) {
   private val globals = spec.globals
   private val controls = spec.controls
   private val controlled = spec.controlled
@@ -386,7 +386,7 @@ case class BoogieTranslator(program: Program, spec: Specification) {
     case _ => ???
   }
 
-  def stripUnreachableFunctions(externalNames: Set[String]): BoogieTranslator = {
+  def stripUnreachableFunctions(externalNames: Set[String]): Unit = {
     val functionToChildren = program.functions.map(f => f.name -> f.calls).toMap
 
     var next = "main"
@@ -405,12 +405,13 @@ case class BoogieTranslator(program: Program, spec: Specification) {
       }
     }
 
-    val reachableFunctions = program.functions.filter(f => reachableNames.contains(f.name))
-    val externalsStubbed = reachableFunctions.map {
-      case f: Subroutine if externalNames.contains(f.name) => f.copy(blocks = List())
-      case f: _ => f
+    program.functions = program.functions.filter(f => reachableNames.contains(f.name))
+    for (f <- program.functions) {
+      f match {
+        case f: Subroutine if externalNames.contains(f.name) => f.blocks = List()
+        case _ =>
+      }
     }
-    copy(program = program.copy(functions = externalsStubbed))
   }
 
   private val reserved = Set("free")

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -59,7 +59,7 @@ object RunUtils {
     val externalNames = externalFunctions.map(e => e.name)
 
     val translator = BoogieTranslator(program, specification)
-    val translatorUnusedRemoved = translator.stripUnreachableFunctions(externalNames)
+    translator.stripUnreachableFunctions(externalNames)
 
     // does not work properly
     //val cfg = IntraproceduralProgramCfg.generateFromProgram(translatorUnusedRemoved.program)
@@ -67,7 +67,7 @@ object RunUtils {
 
 
 
-    translatorUnusedRemoved.translate
+    translator.translate
   }
 
   def writeToFile(program: BProgram, outputFileName: String): Unit = {


### PR DESCRIPTION
Changed the ast to be mutable (ie. by changing the case classes to regular classes). This resulted in the need to manually define copy methods. Also, changes to the match function as classes moved from using the unapply method provided by the case class to matching the class type manually (instance matching) and extracting the class variables.