### PR TITLE
use trim instead of strip in build file so sbt works under java8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ updateExpected := {
         val resultPath = v / (name + "_result.txt")
         if (resultPath.exists()) {
           val result = IO.read(resultPath)
-          val verified = result.strip().equals("Boogie program verifier finished with 0 errors")
+          val verified = result.trim().equals("Boogie program verifier finished with 0 errors")
           if (verified == shouldVerify && outPath.exists()) {
             IO.copyFile(outPath, expectedPath)
           }


### PR DESCRIPTION
This prevented sbt running at all under java8. It would probably be better to just require java11 but it doesn't look like sbt can do that. 