### PR TITLE
refactor cli arg parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ val scalaTests = "org.scalatest" %% "scalatest" % "3.2.10" % "test"
 val scalactic = "org.scalactic" %% "scalactic" % "3.2.10"
 val antlrRuntime = "org.antlr" % "antlr4-runtime" % "4.9.3"
 val sourceCode = "com.lihaoyi" %% "sourcecode" % "0.3.0" 
+val mainArgs = "com.lihaoyi" %% "mainargs" % "0.5.1" 
 
 lazy val root = project
   .in(file("."))
@@ -18,12 +19,13 @@ lazy val root = project
     Antlr4 / antlr4Version := "4.9.3",
     Antlr4 / antlr4GenVisitor := true,
     Antlr4 / antlr4PackageName := Some("BilParser"),
-    Compile / run / mainClass := Some("main"),
+    Compile / run / mainClass := Some("Main"),
     libraryDependencies += javaTests,
     libraryDependencies += antlrRuntime,
     libraryDependencies += scalactic,
     libraryDependencies += scalaTests,
-    libraryDependencies += sourceCode
+    libraryDependencies += sourceCode,
+    libraryDependencies += mainArgs 
   )
 
 lazy val updateExpected = taskKey[Unit]("updates .expected for test cases")

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@
 The BAP-to-Boogie Translator generates semantically equivalent Boogie source files (`.bpl`) from AArch64/ARM64 binaries that have been lifted to the BAP (Binary Analysis Platform) intermediate ADT format. 
 
 ## Installation and use
+
 The tool is OS-independent, but producing input files from a given AArch64 binary is Linux-specific, and all commands given are for Linux. On Windows, WSL2 can be used to run any Linux-specific tasks.
 
 Installing [sbt](https://www.scala-sbt.org/download.html) and [JDK 17](https://openjdk.org/install/) (or higher) is required.
@@ -12,9 +13,22 @@ The tool takes as inputs a BAP ADT file (here denoted with `.adt`) and a file co
 
 To build and run the tool using sbt, use the following command:
 
-`sbt "run file.adt file.relf [file.spec] [output.bpl] [-analyse]"` where the output filename is optional and specification filenames are optional. The specification filename must end in `.spec`.
+`sbt "run --adt file.adt --relf file.relf [--spec file.spec] [--output output.bpl] [--analyse] [--interpret]"` where the output filename is optional and specification filenames are optional. The specification filename must end in `.spec`.
 
-The `-analyse` flag is optional and enables the static analysis functionality.
+The `--analyse` flag is optional and enables the static analysis functionality.
+
+
+```
+BASIL
+  -a --adt <str>     BAP ADT file name.
+  -r --relf <str>    Output of 'readelf -s -r -W'.
+  -s --spec <str>    BASIL specification file.
+  -o --output <str>  Boogie output destination file.
+  -v --verbose       Show extra debugging logs.
+  --analyse          Run static analysis pass.
+  --interpret        Run BASIL IL interpreter.
+  -h --help          Show this help message.
+```
 
 The sbt shell can also be used for multiple tasks with less overhead by executing `sbt` and then the relevant sbt commands.
 
@@ -22,13 +36,11 @@ To build a standalone `.jar` file, use the following command:
 
 `sbt assembly`
 
+This is located at `target/scala-3.1.0/wptool-boogie-assembly-0.0.1.jar`.
+
 To compile the source without running it - this helps IntelliJ highlight things properly:
 
 `sbt compile`
-
-The standalone `.jar` can then be executed with the following command:
-
-`./run.sh file.adt file.relf [file.spec] [output.bpl] [-analyse]`
 
 ## Generating inputs
 The tool takes a `.adt` and a `.relf` file as inputs, which are produced by BAP and readelf, respectively.

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -18,7 +18,7 @@ object Main {
   case class Config(
     @arg(name="adt", short='a', doc="BAP ADT file name.")
       adtFileName: String, 
-    @arg(name="relf", short='r', doc="Output of 'readelf -s -r -W'.")
+    @arg(name="relf", short='r', doc="Name of the file containing the output of 'readelf -s -r -W'.")
       relfFileName: String,
     @arg(name="spec", short='s', doc="BASIL specification file.")
       specFileName: Option[String], 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -36,11 +36,20 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val parser = ParserForClass[Config]
-    val conf = parser.constructOrExit(args)
+    val parsed = parser.constructEither(args)
+
+    val conf = parsed match {
+      case  Right(r) => r
+      case Left(l) => {
+        println(l)
+      }
+    }
+
+
+
 
     if (conf.help.value) {
       println(parser.helpText(sorted=false));
-      System.exit(0);
     }
 
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -42,16 +42,13 @@ object Main {
       case  Right(r) => r
       case Left(l) => {
         println(l)
+        return
       }
     }
-
-
-
 
     if (conf.help.value) {
       println(parser.helpText(sorted=false));
     }
-
 
     Logger.setLevel(LogLevel.WARN)
     if (conf.verbose.value) {

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -39,9 +39,9 @@ class SystemTests extends AnyFunSuite {
     val ADTPath = variationPath + ".adt"
     val RELFPath = variationPath + ".relf"
     if (File(specPath).exists) {
-      main(ADTPath, RELFPath, specPath, outPath)
+      Main.main(Array("--adt", ADTPath, "--relf", RELFPath, "--spec", specPath, "--output", outPath))
     } else {
-      main(ADTPath, RELFPath, outPath)
+      Main.main(Array("--adt", ADTPath, "--relf", RELFPath, "--output", outPath))
     }
     val boogieResult = Seq("boogie", "/printVerifiedProceduresCount:0", outPath).!!
     val resultPath = variationPath + "_result.txt"


### PR DESCRIPTION
Uses lihaoyi/mainargs to parse CLI args in stead of ad-hoc logic. Arguments are no longer positional and all require flags. This is my preference for clarity and simplicity, but isn't compatible with the previous format. 

```
BASIL
  -a --adt <str>     BAP ADT file name.
  -r --relf <str>    Output of 'readelf -s -r -W'.
  -s --spec <str>    BASIL specification file.
  -o --output <str>  Boogie output destination file.
  -v --verbose       Show extra debugging logs.
  --analyse          Run static analysis pass.
  --interpret        Run BASIL IL interpreter.
  -h --help          Show this help message.
```