### PR TITLE
Evaluate literal expressions in vsa

### DIFF
--- a/src/main/scala/analysis/VSA.scala
+++ b/src/main/scala/analysis/VSA.scala
@@ -128,7 +128,14 @@ trait MemoryRegionValueSetAnalysis:
               case None =>
                 println("Warning: could not find region for " + localAssign)
                 s
-          case _ => s
+          case e: Expr => {
+            val evaled = evaluateExpression(e, n, constantProp)
+            evaled match 
+              case bv: BitVecLiteral => s + (localAssign.lhs -> Set(getValueType(evaled.asInstanceOf[BitVecLiteral])))
+              case _ => 
+                println("Warning: could not evaluate expression" + e)
+                s
+          }
       case memAssign: MemoryAssign =>
         memAssign.rhs.index match
           case binOp: BinaryExpr =>


### PR DESCRIPTION
Adds local assign expressions that can be evaluated to literals to the VSA 
Functionally this is just merging the constant propagation results into the vsa

Before commit 93d99378cd96185c71f677f72a7bc3dce3cc6a20 the VSA tracked values of registers, but unclear if this was broken in a merge later or something else. 

