### PR TITLE
Time limits for SystemTests

### DIFF
--- a/src/test/correct/basic_arrays_write/clang_pic/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/clang_pic/basic_arrays_write.expected
@@ -1,0 +1,170 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $arr_addr: bv64;
+axiom ($arr_addr == 69684bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if ((index == bvadd64($arr_addr, 4bv64)) || (index == bvadd64($arr_addr, 0bv64))) then false else false)
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures true;
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures true;
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert true;
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;
+  requires (Gamma_R0 == false);
+  free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1935bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var arr$0_old: bv32;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    R9, Gamma_R9 := 65536bv64, true;
+    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R9, 4056bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4056bv64)) || L(mem, bvadd64(R9, 4056bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
+    call rely();
+    assert (L(mem, bvadd64(R9, 4bv64)) ==> Gamma_R8);
+    arr$0_old := memory_load32_le(mem, bvadd64($arr_addr, 0bv64));
+    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R9, 4bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R9, 4bv64), Gamma_R8);
+    assert (arr$0_old == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
+    R0, Gamma_R0 := 0bv64, true;
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basic_arrays_write/gcc_pic/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/gcc_pic/basic_arrays_write.expected
@@ -1,0 +1,224 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_R31: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var R31: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $arr_addr: bv64;
+axiom ($arr_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if ((index == bvadd64($arr_addr, 4bv64)) || (index == bvadd64($arr_addr, 0bv64))) then false else false)
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures true;
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures true;
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert true;
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;
+  requires (Gamma_R0 == false);
+  free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1935bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 24bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var arr$0_old: bv32;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4080bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4080bv64)) || L(mem, bvadd64(R0, 4080bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
+    call rely();
+    assert (L(mem, bvadd64(R0, 4bv64)) ==> Gamma_R1);
+    arr$0_old := memory_load32_le(mem, bvadd64($arr_addr, 0bv64));
+    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R0, 4bv64), R1[32:0]), gamma_store32(Gamma_mem, bvadd64(R0, 4bv64), Gamma_R1);
+    assert (arr$0_old == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
+    R0, Gamma_R0 := 0bv64, true;
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basic_assign_assign/clang_pic/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/clang_pic/basic_assign_assign.expected
@@ -1,0 +1,157 @@
+var Gamma_R0: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else false)
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  requires (memory_load32_le(mem, $x_addr) == 0bv32);
+  free requires (memory_load8_le(mem, 1920bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1921bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1922bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1923bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  ensures ((memory_load32_le(mem, $x_addr) == 5bv32) || (memory_load32_le(mem, $x_addr) == 6bv32));
+{
+  var x_old: bv32;
+  lmain:
+    R9, Gamma_R9 := 65536bv64, true;
+    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));
+    R8, Gamma_R8 := 5bv64, true;
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
+    assert ((memory_load32_le(mem, $x_addr) == x_old) || (memory_load32_le(mem, $x_addr) == 5bv32));
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_assign_assign/gcc_pic/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/gcc_pic/basic_assign_assign.expected
@@ -1,0 +1,211 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else false)
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
+  requires (memory_load32_le(mem, $x_addr) == 0bv32);
+  free requires (memory_load8_le(mem, 1920bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1921bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1922bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1923bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  ensures ((memory_load32_le(mem, $x_addr) == 5bv32) || (memory_load32_le(mem, $x_addr) == 6bv32));
+{
+  var x_old: bv32;
+  lmain:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    R1, Gamma_R1 := 5bv64, true;
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert ((memory_load32_le(mem, $x_addr) == x_old) || (memory_load32_le(mem, $x_addr) == 5bv32));
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_assign_increment/clang_pic/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/clang_pic/basic_assign_increment.expected
@@ -1,0 +1,164 @@
+var Gamma_R0: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else false)
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  requires (memory_load32_le(mem, $x_addr) == 0bv32);
+  free requires (memory_load8_le(mem, 1924bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1925bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1926bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1927bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  ensures (((memory_load32_le(mem, $x_addr) == 1bv32) || (memory_load32_le(mem, $x_addr) == 5bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+{
+  var x_old: bv32;
+  lmain:
+    R9, Gamma_R9 := 65536bv64, true;
+    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R9)), (gamma_load32(Gamma_mem, R9) || L(mem, R9));
+    R8, Gamma_R8 := zero_extend32_32(bvadd32(R8[32:0], 1bv32)), Gamma_R8;
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
+    assert (((memory_load32_le(mem, $x_addr) == x_old) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_assign_increment/gcc_pic/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/gcc_pic/basic_assign_increment.expected
@@ -1,0 +1,220 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else false)
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
+  requires (memory_load32_le(mem, $x_addr) == 0bv32);
+  free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1935bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  ensures (((memory_load32_le(mem, $x_addr) == 1bv32) || (memory_load32_le(mem, $x_addr) == 5bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+{
+  var x_old: bv32;
+  lmain:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    R1, Gamma_R1 := zero_extend32_32(bvadd32(R0[32:0], 1bv32)), Gamma_R0;
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert (((memory_load32_le(mem, $x_addr) == x_old) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
@@ -1,0 +1,218 @@
+var Gamma_R0: bool;
+var Gamma_R29: bool;
+var Gamma_R30: bool;
+var Gamma_R31: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R29: bv64;
+var R30: bv64;
+var R31: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69688bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then (memory_load32_le(memory, $x_addr) == 1bv32) else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function gamma_store64(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value][bvadd64(index, 4bv64) := value][bvadd64(index, 5bv64) := value][bvadd64(index, 6bv64) := value][bvadd64(index, 7bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]][bvadd64(index, 4bv64) := value[40:32]][bvadd64(index, 5bv64) := value[48:40]][bvadd64(index, 6bv64) := value[56:48]][bvadd64(index, 7bv64) := value[64:56]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R29, R30, R31, R8, R9, mem, stack;
+  requires (Gamma_R0 == false);
+  free requires (memory_load8_le(mem, 1896bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1897bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1898bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1899bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 216bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 28bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  free ensures (Gamma_R29 == old(Gamma_R29));
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R29 == old(R29));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv64;
+  var #5: bv64;
+  var Gamma_#4: bool;
+  var Gamma_#5: bool;
+  var Gamma_y_old: bool;
+  var x_old: bv32;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
+    #4, Gamma_#4 := bvadd64(R31, 16bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(#4, 8bv64), R30), gamma_store64(Gamma_stack, bvadd64(#4, 8bv64), Gamma_R30);
+    R29, Gamma_R29 := bvadd64(R31, 16bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
+    R30, Gamma_R30 := 1840bv64, true;
+    call zero();
+    goto l00000321;
+  l00000321:
+    R8, Gamma_R8 := 69632bv64, true;
+    call rely();
+    assert (L(mem, bvadd64(R8, 52bv64)) ==> Gamma_R0);
+    x_old := memory_load32_le(mem, $x_addr);
+    Gamma_y_old := (gamma_load32(Gamma_mem, $y_addr) || L(mem, $y_addr));
+    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R8, 52bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R8, 52bv64), Gamma_R0);
+    assert ((bvadd64(R8, 52bv64) == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
+    assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+    assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, bvadd64(R29, 18446744073709551612bv64))), (gamma_load32(Gamma_mem, bvadd64(R29, 18446744073709551612bv64)) || L(mem, bvadd64(R29, 18446744073709551612bv64)));
+    R9, Gamma_R9 := 69632bv64, true;
+    call rely();
+    assert (L(mem, bvadd64(R9, 56bv64)) ==> Gamma_R8);
+    x_old := memory_load32_le(mem, $x_addr);
+    Gamma_y_old := (gamma_load32(Gamma_mem, $y_addr) || L(mem, $y_addr));
+    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R9, 56bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R9, 56bv64), Gamma_R8);
+    assert ((bvadd64(R9, 56bv64) == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
+    assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+    assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+    R0, Gamma_R0 := 0bv64, true;
+    #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
+    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
+    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
+    return;
+}
+
+procedure zero()
+  modifies Gamma_R0, R0;
+  ensures ((R0[32:0] == 0bv32) && Gamma_R0);
+{
+  lzero:
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_function_call_caller/clang_no_plt_no_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_no_plt_no_pic/basic_function_call_caller.expected
@@ -1,0 +1,218 @@
+var Gamma_R0: bool;
+var Gamma_R29: bool;
+var Gamma_R30: bool;
+var Gamma_R31: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R29: bv64;
+var R30: bv64;
+var R31: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69688bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then (memory_load32_le(memory, $x_addr) == 1bv32) else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function gamma_store64(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value][bvadd64(index, 4bv64) := value][bvadd64(index, 5bv64) := value][bvadd64(index, 6bv64) := value][bvadd64(index, 7bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]][bvadd64(index, 4bv64) := value[40:32]][bvadd64(index, 5bv64) := value[48:40]][bvadd64(index, 6bv64) := value[56:48]][bvadd64(index, 7bv64) := value[64:56]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R29, R30, R31, R8, R9, mem, stack;
+  requires (Gamma_R0 == false);
+  free requires (memory_load8_le(mem, 1896bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1897bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1898bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1899bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 216bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 28bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  free ensures (Gamma_R29 == old(Gamma_R29));
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R29 == old(R29));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv64;
+  var #5: bv64;
+  var Gamma_#4: bool;
+  var Gamma_#5: bool;
+  var Gamma_y_old: bool;
+  var x_old: bv32;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
+    #4, Gamma_#4 := bvadd64(R31, 16bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(#4, 8bv64), R30), gamma_store64(Gamma_stack, bvadd64(#4, 8bv64), Gamma_R30);
+    R29, Gamma_R29 := bvadd64(R31, 16bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
+    R30, Gamma_R30 := 1840bv64, true;
+    call zero();
+    goto l00000938;
+  l00000938:
+    R8, Gamma_R8 := 69632bv64, true;
+    call rely();
+    assert (L(mem, bvadd64(R8, 52bv64)) ==> Gamma_R0);
+    x_old := memory_load32_le(mem, $x_addr);
+    Gamma_y_old := (gamma_load32(Gamma_mem, $y_addr) || L(mem, $y_addr));
+    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R8, 52bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R8, 52bv64), Gamma_R0);
+    assert ((bvadd64(R8, 52bv64) == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
+    assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+    assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, bvadd64(R29, 18446744073709551612bv64))), (gamma_load32(Gamma_mem, bvadd64(R29, 18446744073709551612bv64)) || L(mem, bvadd64(R29, 18446744073709551612bv64)));
+    R9, Gamma_R9 := 69632bv64, true;
+    call rely();
+    assert (L(mem, bvadd64(R9, 56bv64)) ==> Gamma_R8);
+    x_old := memory_load32_le(mem, $x_addr);
+    Gamma_y_old := (gamma_load32(Gamma_mem, $y_addr) || L(mem, $y_addr));
+    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R9, 56bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R9, 56bv64), Gamma_R8);
+    assert ((bvadd64(R9, 56bv64) == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
+    assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+    assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+    R0, Gamma_R0 := 0bv64, true;
+    #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
+    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
+    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
+    return;
+}
+
+procedure zero()
+  modifies Gamma_R0, R0;
+  ensures ((R0[32:0] == 0bv32) && Gamma_R0);
+{
+  lzero:
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
@@ -1,0 +1,272 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_R29: bool;
+var Gamma_R30: bool;
+var Gamma_R31: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var R29: bv64;
+var R30: bv64;
+var R31: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then (memory_load32_le(memory, $x_addr) == 1bv32) else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function gamma_store64(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value][bvadd64(index, 4bv64) := value][bvadd64(index, 5bv64) := value][bvadd64(index, 6bv64) := value][bvadd64(index, 7bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]][bvadd64(index, 4bv64) := value[40:32]][bvadd64(index, 5bv64) := value[48:40]][bvadd64(index, 6bv64) := value[56:48]][bvadd64(index, 7bv64) := value[64:56]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R29, R30, R31, mem, stack;
+  requires (Gamma_R0 == false);
+  free requires (memory_load8_le(mem, 1900bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1901bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1902bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1903bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 168bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 28bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  free ensures (Gamma_R29 == old(Gamma_R29));
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R29 == old(R29));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv64;
+  var Gamma_#4: bool;
+  var Gamma_y_old: bool;
+  var x_old: bv32;
+  lmain:
+    #4, Gamma_#4 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(#4, 8bv64), R30), gamma_store64(Gamma_stack, bvadd64(#4, 8bv64), Gamma_R30);
+    R31, Gamma_R31 := #4, Gamma_#4;
+    R29, Gamma_R29 := R31, Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
+    R30, Gamma_R30 := 1836bv64, true;
+    call zero();
+    goto l00000323;
+  l00000323:
+    R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
+    R0, Gamma_R0 := 69632bv64, true;
+    R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    x_old := memory_load32_le(mem, $x_addr);
+    Gamma_y_old := (gamma_load32(Gamma_mem, $y_addr) || L(mem, $y_addr));
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert ((R0 == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
+    assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+    assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+    R0, Gamma_R0 := 69632bv64, true;
+    R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    x_old := memory_load32_le(mem, $x_addr);
+    Gamma_y_old := (gamma_load32(Gamma_mem, $y_addr) || L(mem, $y_addr));
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert ((R0 == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
+    assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+    assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+    R0, Gamma_R0 := 0bv64, true;
+    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
+    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
+    return;
+}
+
+procedure zero()
+  modifies Gamma_R0, R0;
+  ensures ((R0[32:0] == 0bv32) && Gamma_R0);
+{
+  lzero:
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_function_call_caller/gcc_no_plt_no_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_no_plt_no_pic/basic_function_call_caller.expected
@@ -1,0 +1,272 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_R29: bool;
+var Gamma_R30: bool;
+var Gamma_R31: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var R29: bv64;
+var R30: bv64;
+var R31: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then (memory_load32_le(memory, $x_addr) == 1bv32) else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function gamma_store64(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value][bvadd64(index, 4bv64) := value][bvadd64(index, 5bv64) := value][bvadd64(index, 6bv64) := value][bvadd64(index, 7bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]][bvadd64(index, 4bv64) := value[40:32]][bvadd64(index, 5bv64) := value[48:40]][bvadd64(index, 6bv64) := value[56:48]][bvadd64(index, 7bv64) := value[64:56]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R29, R30, R31, mem, stack;
+  requires (Gamma_R0 == false);
+  free requires (memory_load8_le(mem, 1900bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1901bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1902bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1903bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 168bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 28bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  free ensures (Gamma_R29 == old(Gamma_R29));
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R29 == old(R29));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv64;
+  var Gamma_#4: bool;
+  var Gamma_y_old: bool;
+  var x_old: bv32;
+  lmain:
+    #4, Gamma_#4 := bvadd64(R31, 18446744073709551584bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store64_le(stack, #4, R29), gamma_store64(Gamma_stack, #4, Gamma_R29);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(#4, 8bv64), R30), gamma_store64(Gamma_stack, bvadd64(#4, 8bv64), Gamma_R30);
+    R31, Gamma_R31 := #4, Gamma_#4;
+    R29, Gamma_R29 := R31, Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
+    R30, Gamma_R30 := 1836bv64, true;
+    call zero();
+    goto l0000094a;
+  l0000094a:
+    R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
+    R0, Gamma_R0 := 69632bv64, true;
+    R0, Gamma_R0 := bvadd64(R0, 20bv64), Gamma_R0;
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    x_old := memory_load32_le(mem, $x_addr);
+    Gamma_y_old := (gamma_load32(Gamma_mem, $y_addr) || L(mem, $y_addr));
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert ((R0 == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
+    assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+    assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+    R0, Gamma_R0 := 69632bv64, true;
+    R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    x_old := memory_load32_le(mem, $x_addr);
+    Gamma_y_old := (gamma_load32(Gamma_mem, $y_addr) || L(mem, $y_addr));
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert ((R0 == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
+    assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+    assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+    R0, Gamma_R0 := 0bv64, true;
+    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
+    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
+    return;
+}
+
+procedure zero()
+  modifies Gamma_R0, R0;
+  ensures ((R0[32:0] == 0bv32) && Gamma_R0);
+{
+  lzero:
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_function_call_reader/clang_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_pic/basic_function_call_reader.expected
@@ -1,0 +1,230 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_R8: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var R8: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69688bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69684bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then (memory_load32_le(memory, $x_addr) == 1bv32) else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
+  free requires (memory_load8_le(mem, 1980bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1981bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1982bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1983bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 200bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 56bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4048bv64)) || L(mem, bvadd64(R8, 4048bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4032bv64)) || L(mem, bvadd64(R8, 4032bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    #4, Gamma_#4 := bvadd32(R8[32:0], 4294967295bv32), Gamma_R8;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R8[32:0]), 0bv33))), (Gamma_R8 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R8[32:0]), 4294967296bv33))), (Gamma_R8 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvcomp1(ZF, 1bv1) != 0bv1)) {
+      goto l00000358;
+    }
+    goto l0000035b;
+  l0000035b:
+    R8, Gamma_R8 := 1bv64, true;
+    goto l0000035e;
+  l00000358:
+    R8, Gamma_R8 := 0bv64, true;
+    goto l0000035e;
+  l0000035e:
+    assert Gamma_R8;
+    if ((bvcomp1(R8[1:0], 1bv1) != 0bv1)) {
+      goto l00000366;
+    }
+    goto l00000390;
+  l00000366:
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
+    goto l0000037b;
+  l00000390:
+    goto l00000391;
+  l00000391:
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    goto l0000037b;
+  l0000037b:
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basic_function_call_reader/gcc_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_pic/basic_function_call_reader.expected
@@ -1,0 +1,266 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then (memory_load32_le(memory, $x_addr) == 1bv32) else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
+  assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
+  free requires (memory_load8_le(mem, 1956bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1957bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1958bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1959bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69512bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69513bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69514bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69515bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69516bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69517bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69518bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69519bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 152bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 24bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4056bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4056bv64)) || L(mem, bvadd64(R0, 4056bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    #4, Gamma_#4 := bvadd32(R0[32:0], 4294967295bv32), Gamma_R0;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R0[32:0]), 0bv33))), (Gamma_R0 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R0[32:0]), 4294967296bv33))), (Gamma_R0 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1)) {
+      goto l00000334;
+    }
+    goto l0000034b;
+  l00000334:
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
+    goto l00000340;
+  l0000034b:
+    R0, Gamma_R0 := 0bv64, true;
+    goto l00000340;
+  l00000340:
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basic_lock_read/clang_pic/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/clang_pic/basic_lock_read.expected
@@ -1,0 +1,229 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_R8: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var R8: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69688bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69684bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else (if (index == $z_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  free requires (memory_load8_le(mem, 1972bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1973bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1974bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1975bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 200bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 56bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  ensures (R0[32:0] == 0bv32);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  var z_old: bv32;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), true);
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4032bv64)) || L(mem, bvadd64(R8, 4032bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    #4, Gamma_#4 := bvadd32(R8[32:0], 4294967295bv32), Gamma_R8;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R8[32:0]), 0bv33))), (Gamma_R8 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R8[32:0]), 4294967296bv33))), (Gamma_R8 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvcomp1(ZF, 1bv1) != 0bv1)) {
+      goto l0000033c;
+    }
+    goto l0000033f;
+  l0000033f:
+    R8, Gamma_R8 := 1bv64, true;
+    goto l00000342;
+  l0000033c:
+    R8, Gamma_R8 := 0bv64, true;
+    goto l00000342;
+  l00000342:
+    assert Gamma_R8;
+    if ((bvcomp1(R8[1:0], 1bv1) != 0bv1)) {
+      goto l0000034a;
+    }
+    goto l00000361;
+  l00000361:
+    goto l00000362;
+  l00000362:
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4040bv64)) || L(mem, bvadd64(R8, 4040bv64)));
+    call rely();
+    assert (L(mem, R8) ==> true);
+    z_old := memory_load32_le(mem, $z_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R8, 0bv32), gamma_store32(Gamma_mem, R8, true);
+    assert (memory_load32_le(mem, $z_addr) == z_old);
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
+    goto l0000034a;
+  l0000034a:
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basic_lock_security_read/clang_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_pic/basic_lock_security_read.expected
@@ -1,0 +1,222 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_R8: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var R8: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69688bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69684bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then (memory_load32_le(memory, $z_addr) == 0bv32) else (if (index == $z_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
+  free requires (memory_load8_le(mem, 1968bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1969bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1970bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1971bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 200bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 56bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), true);
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4032bv64)) || L(mem, bvadd64(R8, 4032bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    #4, Gamma_#4 := bvadd32(R8[32:0], 4294967295bv32), Gamma_R8;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R8[32:0]), 0bv33))), (Gamma_R8 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R8[32:0]), 4294967296bv33))), (Gamma_R8 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvcomp1(ZF, 1bv1) != 0bv1)) {
+      goto l00000338;
+    }
+    goto l0000033b;
+  l0000033b:
+    R8, Gamma_R8 := 1bv64, true;
+    goto l0000033e;
+  l00000338:
+    R8, Gamma_R8 := 0bv64, true;
+    goto l0000033e;
+  l0000033e:
+    assert Gamma_R8;
+    if ((bvcomp1(R8[1:0], 1bv1) != 0bv1)) {
+      goto l00000346;
+    }
+    goto l0000035d;
+  l0000035d:
+    goto l0000035e;
+  l0000035e:
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4040bv64)) || L(mem, bvadd64(R8, 4040bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
+    goto l00000346;
+  l00000346:
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basic_lock_security_read/gcc_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_pic/basic_lock_security_read.expected
@@ -1,0 +1,260 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then (memory_load32_le(memory, $z_addr) == 0bv32) else (if (index == $z_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
+  free requires (memory_load8_le(mem, 1952bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1953bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1954bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1955bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69512bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69513bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69514bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69515bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69516bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69517bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69518bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69519bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 152bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 24bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4056bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4056bv64)) || L(mem, bvadd64(R0, 4056bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    #4, Gamma_#4 := bvadd32(R0[32:0], 4294967295bv32), Gamma_R0;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R0[32:0]), 0bv33))), (Gamma_R0 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R0[32:0]), 4294967296bv33))), (Gamma_R0 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1)) {
+      goto l0000031c;
+    }
+    goto l00000333;
+  l00000333:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
+    goto l0000031c;
+  l0000031c:
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basic_lock_unlock/clang_pic/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/clang_pic/basic_lock_unlock.expected
@@ -1,0 +1,176 @@
+var Gamma_R0: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69688bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else (if (index == $z_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  requires (memory_load32_le(mem, $z_addr) == 1bv32);
+  free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1935bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 200bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 56bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+{
+  var x_old: bv32;
+  var z_old: bv32;
+  lmain:
+    R9, Gamma_R9 := 65536bv64, true;
+    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));
+    R8, Gamma_R8 := 1bv64, true;
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    z_old := memory_load32_le(mem, $z_addr);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
+    assert ((z_old == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == x_old) && (memory_load32_le(mem, $z_addr) == z_old)));
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4032bv64)) || L(mem, bvadd64(R8, 4032bv64)));
+    R0, Gamma_R0 := 0bv64, true;
+    call rely();
+    assert (L(mem, R8) ==> true);
+    z_old := memory_load32_le(mem, $z_addr);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R8, 0bv32), gamma_store32(Gamma_mem, R8, true);
+    assert ((z_old == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == x_old) && (memory_load32_le(mem, $z_addr) == z_old)));
+    return;
+}

--- a/src/test/correct/basic_lock_unlock/gcc_pic/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/gcc_pic/basic_lock_unlock.expected
@@ -1,0 +1,230 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else (if (index == $z_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
+  requires (memory_load32_le(mem, $z_addr) == 1bv32);
+  free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1935bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69512bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69513bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69514bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69515bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69516bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69517bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69518bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69519bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 152bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 24bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+{
+  var x_old: bv32;
+  var z_old: bv32;
+  lmain:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    R1, Gamma_R1 := 1bv64, true;
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    z_old := memory_load32_le(mem, $z_addr);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert ((z_old == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == x_old) && (memory_load32_le(mem, $z_addr) == z_old)));
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4056bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4056bv64)) || L(mem, bvadd64(R0, 4056bv64)));
+    call rely();
+    assert (L(mem, R0) ==> true);
+    z_old := memory_load32_le(mem, $z_addr);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R0, 0bv32), gamma_store32(Gamma_mem, R0, true);
+    assert ((z_old == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == x_old) && (memory_load32_le(mem, $z_addr) == z_old)));
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_loop_assign/clang_pic/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/clang_pic/basic_loop_assign.expected
@@ -1,0 +1,159 @@
+var Gamma_R0: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else false)
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvsle"} bvsle32(bv32, bv32) returns (bool);
+function {:bvbuiltin "bvslt"} bvslt32(bv32, bv32) returns (bool);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(memory_load32_le(mem, $x_addr), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (memory_load32_le(mem, $x_addr) == 20bv32)));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  requires (memory_load32_le(mem, $x_addr) == 0bv32);
+  free requires (memory_load8_le(mem, 1920bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1921bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1922bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1923bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  ensures ((memory_load32_le(mem, $x_addr) == 20bv32) || (memory_load32_le(mem, $x_addr) == 21bv32));
+{
+  var x_old: bv32;
+  lmain:
+    R9, Gamma_R9 := 65536bv64, true;
+    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));
+    R8, Gamma_R8 := 20bv64, true;
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
+    assert (((memory_load32_le(mem, $x_addr) == x_old) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (x_old == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(x_old, 10bv32)));
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_loop_assign/gcc_pic/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/gcc_pic/basic_loop_assign.expected
@@ -1,0 +1,213 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else false)
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvsle"} bvsle32(bv32, bv32) returns (bool);
+function {:bvbuiltin "bvslt"} bvslt32(bv32, bv32) returns (bool);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(memory_load32_le(mem, $x_addr), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (memory_load32_le(mem, $x_addr) == 20bv32)));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
+  requires (memory_load32_le(mem, $x_addr) == 0bv32);
+  free requires (memory_load8_le(mem, 1920bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1921bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1922bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1923bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  ensures ((memory_load32_le(mem, $x_addr) == 20bv32) || (memory_load32_le(mem, $x_addr) == 21bv32));
+{
+  var x_old: bv32;
+  lmain:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    R1, Gamma_R1 := 20bv64, true;
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert (((memory_load32_le(mem, $x_addr) == x_old) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (x_old == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(x_old, 10bv32)));
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basic_sec_policy_read/clang_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_pic/basic_sec_policy_read.expected
@@ -1,0 +1,222 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_R8: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var R8: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69688bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $z_addr) then true else (if (index == $x_addr) then (memory_load32_le(memory, $z_addr) == 0bv32) else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
+  free requires (memory_load8_le(mem, 1968bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1969bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1970bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1971bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 200bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 56bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4040bv64)) || L(mem, bvadd64(R8, 4040bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R8);
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4032bv64)) || L(mem, bvadd64(R8, 4032bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    #4, Gamma_#4 := bvadd32(R8[32:0], 4294967295bv32), Gamma_R8;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R8[32:0]), 0bv33))), (Gamma_R8 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R8[32:0]), 4294967296bv33))), (Gamma_R8 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1)) {
+      goto l0000034c;
+    }
+    goto l0000034f;
+  l0000034f:
+    R8, Gamma_R8 := 1bv64, true;
+    goto l00000352;
+  l0000034c:
+    R8, Gamma_R8 := 0bv64, true;
+    goto l00000352;
+  l00000352:
+    assert Gamma_R8;
+    if ((bvcomp1(R8[1:0], 1bv1) != 0bv1)) {
+      goto l0000035a;
+    }
+    goto l00000371;
+  l00000371:
+    goto l00000372;
+  l00000372:
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 8bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 8bv64), true);
+    goto l0000035a;
+  l0000035a:
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basic_sec_policy_read/gcc_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_pic/basic_sec_policy_read.expected
@@ -1,0 +1,260 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $z_addr) then true else (if (index == $x_addr) then (memory_load32_le(memory, $z_addr) == 0bv32) else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
+  free requires (memory_load8_le(mem, 1952bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1953bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1954bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1955bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69512bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69513bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69514bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69515bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69516bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69517bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69518bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69519bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 152bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 24bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4056bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4056bv64)) || L(mem, bvadd64(R0, 4056bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    #4, Gamma_#4 := bvadd32(R0[32:0], 4294967295bv32), Gamma_R0;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R0[32:0]), 0bv33))), (Gamma_R0 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R0[32:0]), 4294967296bv33))), (Gamma_R0 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvcomp1(ZF, 1bv1) != 0bv1)) {
+      goto l00000330;
+    }
+    goto l00000347;
+  l00000347:
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    goto l00000330;
+  l00000330:
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/basicassign_gamma0/clang_pic/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/clang_pic/basicassign_gamma0.expected
@@ -1,0 +1,167 @@
+var Gamma_R0: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+const $secret_addr: bv64;
+axiom ($secret_addr == 69684bv64);
+const $x_addr: bv64;
+axiom ($x_addr == 69688bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else (if (index == $secret_addr) then false else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $secret_addr) == memory_load32_le(mem, $secret_addr));
+}
+
+procedure guarantee_reflexive();
+  modifies mem, Gamma_mem;
+
+procedure main()
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  requires (gamma_load32(Gamma_mem, $secret_addr) == true);
+  free requires (memory_load8_le(mem, 1928bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1929bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1930bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1931bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 200bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 56bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+{
+  lmain:
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4048bv64)) || L(mem, bvadd64(R8, 4048bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    R9, Gamma_R9 := 65536bv64, true;
+    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R9, 4032bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4032bv64)) || L(mem, bvadd64(R9, 4032bv64)));
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/basicassign_gamma0/gcc_pic/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/gcc_pic/basicassign_gamma0.expected
@@ -1,0 +1,221 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var mem: [bv64]bv8;
+const $secret_addr: bv64;
+axiom ($secret_addr == 69656bv64);
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $x_addr) then true else (if (index == $secret_addr) then false else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $secret_addr) == memory_load32_le(mem, $secret_addr));
+}
+
+procedure guarantee_reflexive();
+  modifies mem, Gamma_mem;
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
+  requires (gamma_load32(Gamma_mem, $secret_addr) == true);
+  free requires (memory_load8_le(mem, 1928bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1929bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1930bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1931bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69512bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69513bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69514bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69515bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69516bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69517bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69518bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69519bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 152bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 24bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+{
+  lmain:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4056bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4056bv64)) || L(mem, bvadd64(R0, 4056bv64)));
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/no_interference_update_x/clang_pic/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/clang_pic/no_interference_update_x.expected
@@ -1,0 +1,158 @@
+var Gamma_R0: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69688bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then true else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  free requires (memory_load8_le(mem, 1920bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1921bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1922bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1923bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  ensures (memory_load32_le(mem, $x_addr) == 1bv32);
+{
+  var y_old: bv32;
+  lmain:
+    R9, Gamma_R9 := 65536bv64, true;
+    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R9, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4040bv64)) || L(mem, bvadd64(R9, 4040bv64)));
+    R8, Gamma_R8 := 1bv64, true;
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    y_old := memory_load32_le(mem, $y_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
+    assert (memory_load32_le(mem, $y_addr) == y_old);
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/no_interference_update_x/gcc_pic/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/gcc_pic/no_interference_update_x.expected
@@ -1,0 +1,212 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then true else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
+  free requires (memory_load8_le(mem, 1920bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1921bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1922bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1923bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  ensures (memory_load32_le(mem, $x_addr) == 1bv32);
+{
+  var y_old: bv32;
+  lmain:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    R1, Gamma_R1 := 1bv64, true;
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    y_old := memory_load32_le(mem, $y_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert (memory_load32_le(mem, $y_addr) == y_old);
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/no_interference_update_y/clang_pic/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/clang_pic/no_interference_update_y.expected
@@ -1,0 +1,158 @@
+var Gamma_R0: bool;
+var Gamma_R8: bool;
+var Gamma_R9: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R8: bv64;
+var R9: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69688bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69684bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then true else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  free requires (memory_load8_le(mem, 1920bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1921bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1922bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1923bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  ensures (memory_load32_le(mem, $y_addr) == 1bv32);
+{
+  var x_old: bv32;
+  lmain:
+    R9, Gamma_R9 := 65536bv64, true;
+    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R9, 4048bv64)), (gamma_load64(Gamma_mem, bvadd64(R9, 4048bv64)) || L(mem, bvadd64(R9, 4048bv64)));
+    R8, Gamma_R8 := 1bv64, true;
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
+    assert (memory_load32_le(mem, $x_addr) == x_old);
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/no_interference_update_y/gcc_pic/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/gcc_pic/no_interference_update_y.expected
@@ -1,0 +1,212 @@
+var Gamma_R0: bool;
+var Gamma_R1: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var R1: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $y_addr: bv64;
+axiom ($y_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $y_addr) then true else (if (index == $x_addr) then true else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
+  free requires (memory_load8_le(mem, 1920bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1921bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1922bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1923bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 24bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+  ensures (memory_load32_le(mem, $y_addr) == 1bv32);
+{
+  var x_old: bv32;
+  lmain:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));
+    R1, Gamma_R1 := 1bv64, true;
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    x_old := memory_load32_le(mem, $x_addr);
+    mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
+    assert (memory_load32_le(mem, $x_addr) == x_old);
+    R0, Gamma_R0 := 0bv64, true;
+    return;
+}

--- a/src/test/correct/using_gamma_conditional/clang_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_pic/using_gamma_conditional.expected
@@ -1,0 +1,215 @@
+var Gamma_R0: bool;
+var Gamma_R31: bool;
+var Gamma_R8: bool;
+var Gamma_mem: [bv64]bool;
+var Gamma_stack: [bv64]bool;
+var R0: bv64;
+var R31: bv64;
+var R8: bv64;
+var mem: [bv64]bv8;
+var stack: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69684bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69688bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $z_addr) then true else (if (index == $x_addr) then (memory_load32_le(memory, $z_addr) == 0bv32) else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function gamma_store32(gammaMap: [bv64]bool, index: bv64, value: bool) returns ([bv64]bool) {
+  gammaMap[index := value][bvadd64(index, 1bv64) := value][bvadd64(index, 2bv64) := value][bvadd64(index, 3bv64) := value]
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns ([bv64]bv8) {
+  memory[index := value[8:0]][bvadd64(index, 1bv64) := value[16:8]][bvadd64(index, 2bv64) := value[24:16]][bvadd64(index, 3bv64) := value[32:24]]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
+}
+
+procedure main()
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
+  requires (gamma_load32(Gamma_mem, $x_addr) == true);
+  free requires (memory_load8_le(mem, 1964bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1965bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1966bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1967bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 208bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 52bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69667bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69668bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69669bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69670bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69671bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69672bv64) == 40bv8);
+  free requires (memory_load8_le(mem, 69673bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69674bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69675bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69676bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69677bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69678bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69679bv64) == 0bv8);
+  free ensures (Gamma_R31 == old(Gamma_R31));
+  free ensures (R31 == old(R31));
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  lmain:
+    R31, Gamma_R31 := bvadd64(R31, 18446744073709551600bv64), Gamma_R31;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    R8, Gamma_R8 := 65536bv64, true;
+    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 4040bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 4040bv64)) || L(mem, bvadd64(R8, 4040bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
+    #4, Gamma_#4 := bvadd32(R8[32:0], 4294967295bv32), Gamma_R8;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R8[32:0]), 0bv33))), (Gamma_R8 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R8[32:0]), 4294967296bv33))), (Gamma_R8 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    R8, Gamma_R8 := zero_extend32_32(bvadd32(#4, 1bv32)), Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvnot1(bvcomp1(ZF, 1bv1)) != 0bv1)) {
+      goto l0000032d;
+    }
+    goto l00000330;
+  l00000330:
+    R8, Gamma_R8 := 1bv64, true;
+    goto l00000333;
+  l0000032d:
+    R8, Gamma_R8 := 0bv64, true;
+    goto l00000333;
+  l00000333:
+    assert Gamma_R8;
+    if ((bvcomp1(R8[1:0], 1bv1) != 0bv1)) {
+      goto l0000033b;
+    }
+    goto l00000363;
+  l0000033b:
+    R8, Gamma_R8 := 1bv64, true;
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
+    goto l0000034e;
+  l00000363:
+    goto l00000364;
+  l00000364:
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), 0bv32), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), true);
+    goto l0000034e;
+  l0000034e:
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
+    R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
+    return;
+}

--- a/src/test/correct/using_gamma_conditional/gcc_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc_pic/using_gamma_conditional.expected
@@ -1,0 +1,235 @@
+var Gamma_R0: bool;
+var Gamma_mem: [bv64]bool;
+var R0: bv64;
+var mem: [bv64]bv8;
+const $x_addr: bv64;
+axiom ($x_addr == 69652bv64);
+const $z_addr: bv64;
+axiom ($z_addr == 69656bv64);
+function L(memory: [bv64]bv8, index: bv64) returns (bool) {
+  (if (index == $z_addr) then true else (if (index == $x_addr) then (memory_load32_le(memory, $z_addr) == 0bv32) else false))
+}
+
+function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
+function {:bvbuiltin "bvadd"} bvadd33(bv33, bv33) returns (bv33);
+function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
+function {:bvbuiltin "bvcomp"} bvcomp1(bv1, bv1) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp32(bv32, bv32) returns (bv1);
+function {:bvbuiltin "bvcomp"} bvcomp33(bv33, bv33) returns (bv1);
+function {:bvbuiltin "bvnot"} bvnot1(bv1) returns (bv1);
+function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
+}
+
+function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
+  (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
+}
+
+function memory_load32_le(memory: [bv64]bv8, index: bv64) returns (bv32) {
+  (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))
+}
+
+function memory_load64_le(memory: [bv64]bv8, index: bv64) returns (bv64) {
+  (memory[bvadd64(index, 7bv64)] ++ (memory[bvadd64(index, 6bv64)] ++ (memory[bvadd64(index, 5bv64)] ++ (memory[bvadd64(index, 4bv64)] ++ (memory[bvadd64(index, 3bv64)] ++ (memory[bvadd64(index, 2bv64)] ++ (memory[bvadd64(index, 1bv64)] ++ memory[index])))))))
+}
+
+function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
+  memory[index]
+}
+
+function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
+function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
+procedure rely();
+  modifies mem, Gamma_mem;
+  ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
+  ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
+
+procedure rely_transitive()
+  modifies mem, Gamma_mem;
+  ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
+{
+  call rely();
+  call rely();
+}
+
+procedure rely_reflexive()
+{
+  assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
+}
+
+procedure guarantee_reflexive()
+  modifies mem, Gamma_mem;
+{
+  assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
+}
+
+procedure main()
+  modifies Gamma_R0, R0;
+  requires (gamma_load32(Gamma_mem, $x_addr) == true);
+  free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
+  free requires (memory_load8_le(mem, 1935bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69520bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69521bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69522bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69523bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69524bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69525bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69526bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69527bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69528bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69529bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69530bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69531bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69532bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69533bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69534bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69535bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69536bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69537bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69538bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69539bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69540bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69541bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69542bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69543bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69544bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69545bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69546bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69547bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69548bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69549bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69550bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69551bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69552bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69553bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69554bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69555bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69556bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69557bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69558bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69559bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69560bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69561bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69562bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69563bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69564bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69565bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69566bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69567bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69568bv64) == 176bv8);
+  free requires (memory_load8_le(mem, 69569bv64) == 5bv8);
+  free requires (memory_load8_le(mem, 69570bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69571bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69572bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69573bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69574bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69575bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69576bv64) == 160bv8);
+  free requires (memory_load8_le(mem, 69577bv64) == 13bv8);
+  free requires (memory_load8_le(mem, 69578bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69579bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69580bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69581bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69582bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69583bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69584bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69585bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69586bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69587bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69588bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69589bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69590bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69591bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69592bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69593bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69594bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69595bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69596bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69597bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69598bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69599bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69600bv64) == 20bv8);
+  free requires (memory_load8_le(mem, 69601bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69602bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69603bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69604bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69605bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69606bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69607bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69608bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69609bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69610bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69611bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69612bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69613bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69614bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69615bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69616bv64) == 84bv8);
+  free requires (memory_load8_le(mem, 69617bv64) == 7bv8);
+  free requires (memory_load8_le(mem, 69618bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69619bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69620bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69621bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69622bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69623bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69624bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69625bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69626bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69627bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69628bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69629bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69630bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69631bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69635bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69636bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69637bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69638bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69639bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69640bv64) == 8bv8);
+  free requires (memory_load8_le(mem, 69641bv64) == 16bv8);
+  free requires (memory_load8_le(mem, 69642bv64) == 1bv8);
+  free requires (memory_load8_le(mem, 69643bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69644bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69645bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69646bv64) == 0bv8);
+  free requires (memory_load8_le(mem, 69647bv64) == 0bv8);
+{
+  var #4: bv32;
+  var CF: bv1;
+  var Gamma_#4: bool;
+  var Gamma_CF: bool;
+  var Gamma_NF: bool;
+  var Gamma_VF: bool;
+  var Gamma_ZF: bool;
+  var NF: bv1;
+  var VF: bv1;
+  var ZF: bv1;
+  lmain:
+    R0, Gamma_R0 := 65536bv64, true;
+    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4064bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4064bv64)) || L(mem, bvadd64(R0, 4064bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
+    #4, Gamma_#4 := bvadd32(R0[32:0], 4294967295bv32), Gamma_R0;
+    VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#4, 1bv32)), bvadd33(sign_extend1_32(R0[32:0]), 0bv33))), (Gamma_R0 && Gamma_#4);
+    CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#4, 1bv32)), bvadd33(zero_extend1_32(R0[32:0]), 4294967296bv33))), (Gamma_R0 && Gamma_#4);
+    ZF, Gamma_ZF := bvcomp32(bvadd32(#4, 1bv32), 0bv32), Gamma_#4;
+    NF, Gamma_NF := bvadd32(#4, 1bv32)[32:31], Gamma_#4;
+    assert Gamma_ZF;
+    if ((bvcomp1(ZF, 1bv1) != 0bv1)) {
+      goto l000002fb;
+    }
+    goto l0000030a;
+  l000002fb:
+    R0, Gamma_R0 := 1bv64, true;
+    goto l00000305;
+  l0000030a:
+    R0, Gamma_R0 := 0bv64, true;
+    goto l00000305;
+  l00000305:
+    return;
+}

--- a/src/test/scala/SystemTests.scala
+++ b/src/test/scala/SystemTests.scala
@@ -44,7 +44,7 @@ class SystemTests extends AnyFunSuite {
       Main.main(Array("--adt", ADTPath, "--relf", RELFPath, "--output", outPath))
     }
     println(outPath)
-    val boogieResult = Seq("boogie", "/printVerifiedProceduresCount:0", outPath).!!
+    val boogieResult = Seq("boogie", "/timeLimit:10", "/printVerifiedProceduresCount:0", outPath).!!
     val resultPath = variationPath + "_result.txt"
     log(boogieResult, resultPath)
     val verified = boogieResult.strip().equals("Boogie program verifier finished with 0 errors")


### PR DESCRIPTION
Addressing #77 a little bit. With these time limits the tests still take far too long on the latest Boogie (~15 minutes on Boogie 3.0.4 vs. ~4 minutes on 2.16.0 on my machine) but at least they're runnable. 