### PR TITLE
Fix outdated example specs

### DIFF
--- a/examples/basic_arrays_read/basic_arrays_read.spec
+++ b/examples/basic_arrays_read/basic_arrays_read.spec
@@ -1,6 +1,6 @@
 Globals:
 arr: int[2]
 
-L: arr[0] -> false, arr[1] -> false
+L: arr -> false
 Rely: old(arr[0]) == arr[0]
 Guarantee: true

--- a/examples/basic_arrays_write/basic_arrays_write.spec
+++ b/examples/basic_arrays_write/basic_arrays_write.spec
@@ -1,7 +1,7 @@
 Globals:
 arr: int[2]
 
-L: arr[0] -> false, arr[1] -> false
+L: arr -> false
 Rely: true
 Guarantee: old(arr[0]) == arr[0]
 


### PR DESCRIPTION
#87

These specs had been updated in the tests folder but not the examples folder when the implementation changed. A further cleanup there will need to happen at some point, but this will prevent any confusion with this example for now.