### PR TITLE
Stack Identification Bug Fix

### DIFF
--- a/src/main/scala/ir/Visitor.scala
+++ b/src/main/scala/ir/Visitor.scala
@@ -312,3 +312,27 @@ class ExternalRemover(external: Set[String]) extends Visitor {
     super.visitProcedure(node)
   }
 }
+
+/** Gives variables that are not contained within a MemoryStore or MemoryLoad
+  * */
+class VariablesWithoutStoresLoads extends ReadOnlyVisitor {
+  val variables: mutable.Set[Variable] = mutable.Set()
+
+  override def visitRegister(node: Register): Register = {
+    variables.add(node)
+    node
+  }
+  override def visitLocalVar(node: LocalVar): LocalVar = {
+    variables.add(node)
+    node
+  }
+
+  override def visitMemoryStore(node: MemoryStore): MemoryStore = {
+    node
+  }
+
+  override def visitMemoryLoad(node: MemoryLoad): MemoryLoad = {
+    node
+  }
+
+}

--- a/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
@@ -190,7 +190,7 @@ procedure main()
     assert ((bvadd64(R8, 52bv64) == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
     assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
     assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
-    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, bvadd64(R29, 18446744073709551612bv64))), (gamma_load32(Gamma_mem, bvadd64(R29, 18446744073709551612bv64)) || L(mem, bvadd64(R29, 18446744073709551612bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(stack, bvadd64(R29, 18446744073709551612bv64))), gamma_load32(Gamma_stack, bvadd64(R29, 18446744073709551612bv64));
     R9, Gamma_R9 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R9, 56bv64)) ==> Gamma_R8);
@@ -202,8 +202,8 @@ procedure main()
     assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
     R0, Gamma_R0 := 0bv64, true;
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basic_function_call_caller/clang_no_plt_no_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_no_plt_no_pic/basic_function_call_caller.expected
@@ -190,7 +190,7 @@ procedure main()
     assert ((bvadd64(R8, 52bv64) == $x_addr) ==> (L(mem, $y_addr) ==> Gamma_y_old));
     assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
     assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
-    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, bvadd64(R29, 18446744073709551612bv64))), (gamma_load32(Gamma_mem, bvadd64(R29, 18446744073709551612bv64)) || L(mem, bvadd64(R29, 18446744073709551612bv64)));
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(stack, bvadd64(R29, 18446744073709551612bv64))), gamma_load32(Gamma_stack, bvadd64(R29, 18446744073709551612bv64));
     R9, Gamma_R9 := 69632bv64, true;
     call rely();
     assert (L(mem, bvadd64(R9, 56bv64)) ==> Gamma_R8);
@@ -202,8 +202,8 @@ procedure main()
     assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
     R0, Gamma_R0 := 0bv64, true;
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
@@ -246,7 +246,7 @@ procedure main()
     assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     x_old := memory_load32_le(mem, $x_addr);
@@ -256,8 +256,8 @@ procedure main()
     assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
     assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basic_function_call_caller/gcc_no_plt_no_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_no_plt_no_pic/basic_function_call_caller.expected
@@ -246,7 +246,7 @@ procedure main()
     assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
     R0, Gamma_R0 := 69632bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 24bv64), Gamma_R0;
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     x_old := memory_load32_le(mem, $x_addr);
@@ -256,8 +256,8 @@ procedure main()
     assert ((x_old == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
     assert (Gamma_y_old ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basicfree/clang/basicfree.expected
+++ b/src/test/correct/basicfree/clang/basicfree.expected
@@ -161,22 +161,20 @@ procedure main()
     call malloc();
     goto l0000030d;
   l0000030d:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 1bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2048bv64, true;
     call #free();
     goto l00000338;
   l00000338:
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basicfree/clang_no_plt_no_pic/basicfree.expected
+++ b/src/test/correct/basicfree/clang_no_plt_no_pic/basicfree.expected
@@ -161,22 +161,20 @@ procedure main()
     call malloc();
     goto l000008ed;
   l000008ed:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 1bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2048bv64, true;
     call #free();
     goto l00000918;
   l00000918:
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basicfree/clang_pic/basicfree.expected
+++ b/src/test/correct/basicfree/clang_pic/basicfree.expected
@@ -161,22 +161,20 @@ procedure main()
     call malloc();
     goto l000008ed;
   l000008ed:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 1bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2048bv64, true;
     call #free();
     goto l00000918;
   l00000918:
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basicfree/gcc/basicfree.expected
+++ b/src/test/correct/basicfree/gcc/basicfree.expected
@@ -229,21 +229,19 @@ procedure main()
     call malloc();
     goto l00000307;
   l00000307:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R1, Gamma_R1 := 1bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2044bv64, true;
     call #free();
     goto l00000332;
   l00000332:
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basicfree/gcc_no_plt_no_pic/basicfree.expected
+++ b/src/test/correct/basicfree/gcc_no_plt_no_pic/basicfree.expected
@@ -229,21 +229,19 @@ procedure main()
     call malloc();
     goto l000008dc;
   l000008dc:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R1, Gamma_R1 := 1bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2044bv64, true;
     call #free();
     goto l00000907;
   l00000907:
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/basicfree/gcc_pic/basicfree.expected
+++ b/src/test/correct/basicfree/gcc_pic/basicfree.expected
@@ -229,21 +229,19 @@ procedure main()
     call malloc();
     goto l000008dc;
   l000008dc:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R1, Gamma_R1 := 1bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2044bv64, true;
     call #free();
     goto l00000907;
   l00000907:
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function/clang/function.expected
+++ b/src/test/correct/function/clang/function.expected
@@ -183,8 +183,8 @@ procedure main()
     assert (L(mem, bvadd64(R8, 56bv64)) ==> Gamma_R0);
     mem, Gamma_mem := memory_store32_le(mem, bvadd64(R8, 56bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R8, 56bv64), Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function/clang_no_plt_no_pic/function.expected
+++ b/src/test/correct/function/clang_no_plt_no_pic/function.expected
@@ -183,8 +183,8 @@ procedure main()
     assert (L(mem, bvadd64(R8, 56bv64)) ==> Gamma_R0);
     mem, Gamma_mem := memory_store32_le(mem, bvadd64(R8, 56bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R8, 56bv64), Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function/clang_pic/function.expected
+++ b/src/test/correct/function/clang_pic/function.expected
@@ -201,8 +201,8 @@ procedure main()
     assert (L(mem, R8) ==> Gamma_R0);
     mem, Gamma_mem := memory_store32_le(mem, R8, R0[32:0]), gamma_store32(Gamma_mem, R8, Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function/gcc/function.expected
+++ b/src/test/correct/function/gcc/function.expected
@@ -241,8 +241,8 @@ procedure main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function/gcc_no_plt_no_pic/function.expected
+++ b/src/test/correct/function/gcc_no_plt_no_pic/function.expected
@@ -241,8 +241,8 @@ procedure main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function/gcc_pic/function.expected
+++ b/src/test/correct/function/gcc_pic/function.expected
@@ -257,8 +257,8 @@ procedure main()
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function1/clang/function1.expected
+++ b/src/test/correct/function1/clang/function1.expected
@@ -234,8 +234,8 @@ procedure main()
     goto l000003f5;
   l000003f5:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function1/clang_O2/function1.expected
+++ b/src/test/correct/function1/clang_O2/function1.expected
@@ -187,8 +187,8 @@ procedure main()
     goto l00000371;
   l00000371:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function1/clang_no_plt_no_pic/function1.expected
+++ b/src/test/correct/function1/clang_no_plt_no_pic/function1.expected
@@ -234,8 +234,8 @@ procedure main()
     goto l00000b06;
   l00000b06:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function1/clang_pic/function1.expected
+++ b/src/test/correct/function1/clang_pic/function1.expected
@@ -252,8 +252,8 @@ procedure main()
     goto l0000040b;
   l0000040b:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function1/gcc/function1.expected
+++ b/src/test/correct/function1/gcc/function1.expected
@@ -303,8 +303,8 @@ procedure main()
     goto l00000430;
   l00000430:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function1/gcc_O2/function1.expected
+++ b/src/test/correct/function1/gcc_O2/function1.expected
@@ -251,8 +251,8 @@ procedure main()
     goto l0000021a;
   l0000021a:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function1/gcc_no_plt_no_pic/function1.expected
+++ b/src/test/correct/function1/gcc_no_plt_no_pic/function1.expected
@@ -303,8 +303,8 @@ procedure main()
     goto l00000b88;
   l00000b88:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/function1/gcc_pic/function1.expected
+++ b/src/test/correct/function1/gcc_pic/function1.expected
@@ -319,8 +319,8 @@ procedure main()
     goto l00000433;
   l00000433:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/functions_with_params/clang/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang/functions_with_params.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1912bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
@@ -78,7 +74,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R29, R30, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;
   free requires (memory_load8_le(mem, 1912bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1913bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1914bv64) == 2bv8);
@@ -171,13 +167,11 @@ procedure main()
     call plus_one();
     goto l00000366;
   l00000366:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551612bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/functions_with_params/clang_no_plt_no_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang_no_plt_no_pic/functions_with_params.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1912bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
@@ -78,7 +74,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R29, R30, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;
   free requires (memory_load8_le(mem, 1912bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1913bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1914bv64) == 2bv8);
@@ -171,13 +167,11 @@ procedure main()
     call plus_one();
     goto l000009b1;
   l000009b1:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551612bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/functions_with_params/clang_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang_pic/functions_with_params.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1912bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
@@ -78,7 +74,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R29, R30, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;
   free requires (memory_load8_le(mem, 1912bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1913bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1914bv64) == 2bv8);
@@ -171,13 +167,11 @@ procedure main()
     call plus_one();
     goto l000009b1;
   l000009b1:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551612bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551612bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551612bv64), Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
     #5, Gamma_#5 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/functions_with_params/gcc/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc/functions_with_params.expected
@@ -12,10 +12,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1904bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
@@ -76,7 +72,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1904bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1905bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1906bv64) == 2bv8);
@@ -223,12 +219,10 @@ procedure main()
     call plus_one();
     goto l0000035c;
   l0000035c:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/functions_with_params/gcc_no_plt_no_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc_no_plt_no_pic/functions_with_params.expected
@@ -12,10 +12,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1904bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
@@ -76,7 +72,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1904bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1905bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1906bv64) == 2bv8);
@@ -223,12 +219,10 @@ procedure main()
     call plus_one();
     goto l00000993;
   l00000993:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/functions_with_params/gcc_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc_pic/functions_with_params.expected
@@ -12,10 +12,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1904bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd32(bv32, bv32) returns (bv32);
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
@@ -76,7 +72,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1904bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1905bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1906bv64) == 2bv8);
@@ -223,12 +219,10 @@ procedure main()
     call plus_one();
     goto l00000993;
   l00000993:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 24bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/indirect_call/clang/indirect_call.expected
+++ b/src/test/correct/indirect_call/clang/indirect_call.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1996bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
@@ -217,16 +213,16 @@ procedure main()
     call printf();
     goto l000003a9;
   l000003a9:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 1960bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l000003b8;
   l000003b8:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/indirect_call/clang_O2/indirect_call.expected
+++ b/src/test/correct/indirect_call/clang_O2/indirect_call.expected
@@ -12,10 +12,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1952bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -195,8 +191,8 @@ procedure main()
     goto l00000332;
   l00000332:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/indirect_call/clang_no_plt_no_pic/indirect_call.expected
+++ b/src/test/correct/indirect_call/clang_no_plt_no_pic/indirect_call.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1996bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
@@ -217,16 +213,16 @@ procedure main()
     call printf();
     goto l00000a77;
   l00000a77:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 1960bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000a86;
   l00000a86:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/indirect_call/clang_pic/indirect_call.expected
+++ b/src/test/correct/indirect_call/clang_pic/indirect_call.expected
@@ -225,16 +225,16 @@ procedure main()
     call printf();
     goto l000003aa;
   l000003aa:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2024bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l000003b9;
   l000003b9:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/indirect_call/gcc/indirect_call.expected
+++ b/src/test/correct/indirect_call/gcc/indirect_call.expected
@@ -12,10 +12,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1984bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -261,15 +257,15 @@ procedure main()
     call puts();
     goto l00000385;
   l00000385:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 1948bv64, true;
     //UNRESOLVED: call R0
     assume false;
     goto l00000394;
   l00000394:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/indirect_call/gcc_O2/indirect_call.expected
+++ b/src/test/correct/indirect_call/gcc_O2/indirect_call.expected
@@ -12,10 +12,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1984bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -274,8 +270,8 @@ procedure main()
     goto l00000205;
   l00000205:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/indirect_call/gcc_no_plt_no_pic/indirect_call.expected
+++ b/src/test/correct/indirect_call/gcc_no_plt_no_pic/indirect_call.expected
@@ -12,10 +12,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1984bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -261,15 +257,15 @@ procedure main()
     call puts();
     goto l00000a1f;
   l00000a1f:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 1948bv64, true;
     //UNRESOLVED: call R0
     assume false;
     goto l00000a2e;
   l00000a2e:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/indirect_call/gcc_pic/indirect_call.expected
+++ b/src/test/correct/indirect_call/gcc_pic/indirect_call.expected
@@ -269,15 +269,15 @@ procedure main()
     call puts();
     goto l00000386;
   l00000386:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2012bv64, true;
     //UNRESOLVED: call R0
     assume false;
     goto l00000395;
   l00000395:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable/clang/jumptable.expected
+++ b/src/test/correct/jumptable/clang/jumptable.expected
@@ -204,22 +204,22 @@ procedure main()
     assume false;
     goto l00000433;
   l00000433:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2008bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000442;
   l00000442:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2016bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000451;
   l00000451:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable/clang_no_plt_no_pic/jumptable.expected
+++ b/src/test/correct/jumptable/clang_no_plt_no_pic/jumptable.expected
@@ -232,22 +232,22 @@ procedure main()
     assume false;
     goto l00000b8d;
   l00000b8d:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2008bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000b9c;
   l00000b9c:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2016bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000bab;
   l00000bab:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable/clang_pic/jumptable.expected
+++ b/src/test/correct/jumptable/clang_pic/jumptable.expected
@@ -212,22 +212,22 @@ procedure main()
     assume false;
     goto l00000454;
   l00000454:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2084bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000463;
   l00000463:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2092bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000472;
   l00000472:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable/gcc/jumptable.expected
+++ b/src/test/correct/jumptable/gcc/jumptable.expected
@@ -306,13 +306,13 @@ procedure main()
     assume false;
     goto l000004d7;
   l000004d7:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2324bv64, true;
     //UNRESOLVED: call R0
     assume false;
     goto l000004e6;
   l000004e6:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R30, Gamma_R30 := 2332bv64, true;
     //UNRESOLVED: call R0
     assume false;
@@ -322,7 +322,7 @@ procedure main()
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 65536bv64, true;
     R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));
-    R3, Gamma_R3 := memory_load64_le(mem, bvadd64(R31, 56bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 56bv64)) || L(mem, bvadd64(R31, 56bv64)));
+    R3, Gamma_R3 := memory_load64_le(stack, bvadd64(R31, 56bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 56bv64));
     R2, Gamma_R2 := memory_load64_le(mem, R0), (gamma_load64(Gamma_mem, R0) || L(mem, R0));
     #5, Gamma_#5 := bvnot64(R2), Gamma_R2;
     #6, Gamma_#6 := bvadd64(R3, bvnot64(R2)), (Gamma_R2 && Gamma_R3);
@@ -343,8 +343,8 @@ procedure main()
     goto l00000544;
   l00000544:
     R0, Gamma_R0 := zero_extend32_32(R1[32:0]), Gamma_R1;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 64bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable/gcc_O2/jumptable.expected
+++ b/src/test/correct/jumptable/gcc_O2/jumptable.expected
@@ -261,8 +261,8 @@ procedure main()
     goto l0000028a;
   l0000028a:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable/gcc_pic/jumptable.expected
+++ b/src/test/correct/jumptable/gcc_pic/jumptable.expected
@@ -314,13 +314,13 @@ procedure main()
     assume false;
     goto l000004dd;
   l000004dd:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2324bv64, true;
     //UNRESOLVED: call R0
     assume false;
     goto l000004ec;
   l000004ec:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R30, Gamma_R30 := 2332bv64, true;
     //UNRESOLVED: call R0
     assume false;
@@ -330,7 +330,7 @@ procedure main()
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 65536bv64, true;
     R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R0, 4072bv64)), (gamma_load64(Gamma_mem, bvadd64(R0, 4072bv64)) || L(mem, bvadd64(R0, 4072bv64)));
-    R3, Gamma_R3 := memory_load64_le(mem, bvadd64(R31, 56bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 56bv64)) || L(mem, bvadd64(R31, 56bv64)));
+    R3, Gamma_R3 := memory_load64_le(stack, bvadd64(R31, 56bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 56bv64));
     R2, Gamma_R2 := memory_load64_le(mem, R0), (gamma_load64(Gamma_mem, R0) || L(mem, R0));
     #5, Gamma_#5 := bvnot64(R2), Gamma_R2;
     #6, Gamma_#6 := bvadd64(R3, bvnot64(R2)), (Gamma_R2 && Gamma_R3);
@@ -351,8 +351,8 @@ procedure main()
     goto l0000054a;
   l0000054a:
     R0, Gamma_R0 := zero_extend32_32(R1[32:0]), Gamma_R1;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 64bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable2/clang/jumptable2.expected
+++ b/src/test/correct/jumptable2/clang/jumptable2.expected
@@ -216,24 +216,24 @@ procedure main()
     assume false;
     goto l00000422;
   l00000422:
-    R8, Gamma_R8 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
+    R8, Gamma_R8 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 8bv64)) || L(mem, bvadd64(R8, 8bv64)));
     R30, Gamma_R30 := 2004bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000438;
   l00000438:
-    R8, Gamma_R8 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
+    R8, Gamma_R8 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 16bv64)) || L(mem, bvadd64(R8, 16bv64)));
     R30, Gamma_R30 := 2016bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l0000044e;
   l0000044e:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable2/clang_O2/jumptable2.expected
+++ b/src/test/correct/jumptable2/clang_O2/jumptable2.expected
@@ -204,9 +204,9 @@ procedure main()
     goto l000003db;
   l000003db:
     R0, Gamma_R0 := 0bv64, true;
-    R19, Gamma_R19 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R19, Gamma_R19 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable2/clang_no_plt_no_pic/jumptable2.expected
+++ b/src/test/correct/jumptable2/clang_no_plt_no_pic/jumptable2.expected
@@ -216,24 +216,24 @@ procedure main()
     assume false;
     goto l00000b79;
   l00000b79:
-    R8, Gamma_R8 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
+    R8, Gamma_R8 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 8bv64)) || L(mem, bvadd64(R8, 8bv64)));
     R30, Gamma_R30 := 2004bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000b8f;
   l00000b8f:
-    R8, Gamma_R8 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
+    R8, Gamma_R8 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 16bv64)) || L(mem, bvadd64(R8, 16bv64)));
     R30, Gamma_R30 := 2016bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000ba5;
   l00000ba5:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable2/clang_pic/jumptable2.expected
+++ b/src/test/correct/jumptable2/clang_pic/jumptable2.expected
@@ -231,24 +231,24 @@ procedure main()
     assume false;
     goto l0000043b;
   l0000043b:
-    R8, Gamma_R8 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
+    R8, Gamma_R8 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 8bv64)) || L(mem, bvadd64(R8, 8bv64)));
     R30, Gamma_R30 := 2076bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000451;
   l00000451:
-    R8, Gamma_R8 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
+    R8, Gamma_R8 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
     R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R8, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R8, 16bv64)) || L(mem, bvadd64(R8, 16bv64)));
     R30, Gamma_R30 := 2088bv64, true;
     //UNRESOLVED: call R8
     assume false;
     goto l00000467;
   l00000467:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #6, Gamma_#6 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable2/gcc/jumptable2.expected
+++ b/src/test/correct/jumptable2/gcc/jumptable2.expected
@@ -269,8 +269,8 @@ procedure main()
     goto l00000472;
   l00000472:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable2/gcc_O2/jumptable2.expected
+++ b/src/test/correct/jumptable2/gcc_O2/jumptable2.expected
@@ -258,9 +258,9 @@ procedure main()
     goto l00000254;
   l00000254:
     R0, Gamma_R0 := 0bv64, true;
-    R19, Gamma_R19 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R19, Gamma_R19 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable2/gcc_no_plt_no_pic/jumptable2.expected
+++ b/src/test/correct/jumptable2/gcc_no_plt_no_pic/jumptable2.expected
@@ -269,8 +269,8 @@ procedure main()
     goto l00000bf3;
   l00000bf3:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/jumptable2/gcc_pic/jumptable2.expected
+++ b/src/test/correct/jumptable2/gcc_pic/jumptable2.expected
@@ -285,8 +285,8 @@ procedure main()
     goto l0000047b;
   l0000047b:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local/clang/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang/malloc_with_local.expected
@@ -248,32 +248,26 @@ procedure main()
     call malloc();
     goto l00000391;
   l00000391:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2112bv64, true;
     call malloc();
     goto l000003a5;
   l000003a5:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 4bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 4bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 4bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2260bv64), Gamma_R0;
@@ -281,7 +275,7 @@ procedure main()
     call printf();
     goto l00000403;
   l00000403:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2277bv64), Gamma_R0;
@@ -289,27 +283,27 @@ procedure main()
     call printf();
     goto l00000423;
   l00000423:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 4bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 4bv64)) || L(mem, bvadd64(R31, 4bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 4bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2293bv64), Gamma_R0;
     R30, Gamma_R30 := 2204bv64, true;
     call printf();
     goto l0000043c;
   l0000043c:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2212bv64, true;
     call #free();
     goto l0000044b;
   l0000044b:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2220bv64, true;
     call #free();
     goto l00000459;
   l00000459:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R31)), (gamma_load32(Gamma_mem, R31) || L(mem, R31));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, R31)), gamma_load32(Gamma_stack, R31);
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local/clang_O2/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_O2/malloc_with_local.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1964bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -224,8 +220,8 @@ procedure main()
     goto l00000350;
   l00000350:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local/clang_no_plt_no_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_no_plt_no_pic/malloc_with_local.expected
@@ -248,32 +248,26 @@ procedure main()
     call malloc();
     goto l00000b03;
   l00000b03:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2112bv64, true;
     call malloc();
     goto l00000b17;
   l00000b17:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 4bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 4bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 4bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2260bv64), Gamma_R0;
@@ -281,7 +275,7 @@ procedure main()
     call printf();
     goto l00000b75;
   l00000b75:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2277bv64), Gamma_R0;
@@ -289,27 +283,27 @@ procedure main()
     call printf();
     goto l00000b95;
   l00000b95:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 4bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 4bv64)) || L(mem, bvadd64(R31, 4bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 4bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2293bv64), Gamma_R0;
     R30, Gamma_R30 := 2204bv64, true;
     call printf();
     goto l00000bae;
   l00000bae:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2212bv64, true;
     call #free();
     goto l00000bbd;
   l00000bbd:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2220bv64, true;
     call #free();
     goto l00000bcb;
   l00000bcb:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R31)), (gamma_load32(Gamma_mem, R31) || L(mem, R31));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, R31)), gamma_load32(Gamma_stack, R31);
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local/clang_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_pic/malloc_with_local.expected
@@ -248,32 +248,26 @@ procedure main()
     call malloc();
     goto l00000b03;
   l00000b03:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2112bv64, true;
     call malloc();
     goto l00000b17;
   l00000b17:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 4bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 4bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 4bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 4bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2260bv64), Gamma_R0;
@@ -281,7 +275,7 @@ procedure main()
     call printf();
     goto l00000b75;
   l00000b75:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2277bv64), Gamma_R0;
@@ -289,27 +283,27 @@ procedure main()
     call printf();
     goto l00000b95;
   l00000b95:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 4bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 4bv64)) || L(mem, bvadd64(R31, 4bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 4bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2293bv64), Gamma_R0;
     R30, Gamma_R30 := 2204bv64, true;
     call printf();
     goto l00000bae;
   l00000bae:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2212bv64, true;
     call #free();
     goto l00000bbd;
   l00000bbd:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2220bv64, true;
     call #free();
     goto l00000bcb;
   l00000bcb:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R31)), (gamma_load32(Gamma_mem, R31) || L(mem, R31));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, R31)), gamma_load32(Gamma_stack, R31);
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local/gcc/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc/malloc_with_local.expected
@@ -330,32 +330,26 @@ procedure main()
     call malloc();
     goto l0000036f;
   l0000036f:
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2096bv64, true;
     call malloc();
     goto l00000383;
   l00000383:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -364,7 +358,7 @@ procedure main()
     call printf();
     goto l000003e7;
   l000003e7:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -373,26 +367,26 @@ procedure main()
     call printf();
     goto l0000040d;
   l0000040d:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2296bv64), Gamma_R0;
     R30, Gamma_R30 := 2196bv64, true;
     call printf();
     goto l00000426;
   l00000426:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2204bv64, true;
     call #free();
     goto l00000435;
   l00000435:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2212bv64, true;
     call #free();
     goto l00000443;
   l00000443:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local/gcc_O2/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_O2/malloc_with_local.expected
@@ -16,10 +16,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 2088bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -306,8 +302,8 @@ procedure main()
     goto l00000259;
   l00000259:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local/gcc_no_plt_no_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_no_plt_no_pic/malloc_with_local.expected
@@ -330,32 +330,26 @@ procedure main()
     call malloc();
     goto l00000ac0;
   l00000ac0:
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2096bv64, true;
     call malloc();
     goto l00000ad4;
   l00000ad4:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -364,7 +358,7 @@ procedure main()
     call printf();
     goto l00000b38;
   l00000b38:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -373,26 +367,26 @@ procedure main()
     call printf();
     goto l00000b5e;
   l00000b5e:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2296bv64), Gamma_R0;
     R30, Gamma_R30 := 2196bv64, true;
     call printf();
     goto l00000b77;
   l00000b77:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2204bv64, true;
     call #free();
     goto l00000b86;
   l00000b86:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2212bv64, true;
     call #free();
     goto l00000b94;
   l00000b94:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local/gcc_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_pic/malloc_with_local.expected
@@ -330,32 +330,26 @@ procedure main()
     call malloc();
     goto l00000ac0;
   l00000ac0:
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2096bv64, true;
     call malloc();
     goto l00000ad4;
   l00000ad4:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -364,7 +358,7 @@ procedure main()
     call printf();
     goto l00000b38;
   l00000b38:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -373,26 +367,26 @@ procedure main()
     call printf();
     goto l00000b5e;
   l00000b5e:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2296bv64), Gamma_R0;
     R30, Gamma_R30 := 2196bv64, true;
     call printf();
     goto l00000b77;
   l00000b77:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2204bv64, true;
     call #free();
     goto l00000b86;
   l00000b86:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2212bv64, true;
     call #free();
     goto l00000b94;
   l00000b94:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local2/clang/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang/malloc_with_local2.expected
@@ -248,52 +248,38 @@ procedure main()
     call malloc();
     goto l000003b5;
   l000003b5:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551600bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
     R8, Gamma_R8 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551596bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
     R0, Gamma_R0 := 4bv64, true;
-    call rely();
-    assert (L(mem, R31) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, R31, R0), gamma_store64(Gamma_mem, R31, Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, R31, R0), gamma_store64(Gamma_stack, R31, Gamma_R0);
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l000003de;
   l000003de:
     R8, Gamma_R8 := R0, Gamma_R0;
-    R0, Gamma_R0 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R8);
+    R0, Gamma_R0 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R8);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R8);
     R30, Gamma_R30 := 2148bv64, true;
     call malloc();
     goto l00000407;
   l00000407:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R8, Gamma_R8 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2296bv64), Gamma_R0;
@@ -301,7 +287,7 @@ procedure main()
     call printf();
     goto l00000465;
   l00000465:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2313bv64), Gamma_R0;
@@ -309,27 +295,27 @@ procedure main()
     call printf();
     goto l00000485;
   l00000485:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2329bv64), Gamma_R0;
     R30, Gamma_R30 := 2240bv64, true;
     call printf();
     goto l0000049e;
   l0000049e:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2248bv64, true;
     call #free();
     goto l000004ad;
   l000004ad:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2256bv64, true;
     call #free();
     goto l000004bb;
   l000004bb:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 8bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     #5, Gamma_#5 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local2/clang_O2/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_O2/malloc_with_local2.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1964bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -224,8 +220,8 @@ procedure main()
     goto l00000350;
   l00000350:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local2/clang_no_plt_no_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_no_plt_no_pic/malloc_with_local2.expected
@@ -248,52 +248,38 @@ procedure main()
     call malloc();
     goto l00000b92;
   l00000b92:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551600bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
     R8, Gamma_R8 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551596bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
     R0, Gamma_R0 := 4bv64, true;
-    call rely();
-    assert (L(mem, R31) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, R31, R0), gamma_store64(Gamma_mem, R31, Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, R31, R0), gamma_store64(Gamma_stack, R31, Gamma_R0);
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000bbb;
   l00000bbb:
     R8, Gamma_R8 := R0, Gamma_R0;
-    R0, Gamma_R0 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R8);
+    R0, Gamma_R0 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R8);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R8);
     R30, Gamma_R30 := 2148bv64, true;
     call malloc();
     goto l00000be4;
   l00000be4:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R8, Gamma_R8 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2296bv64), Gamma_R0;
@@ -301,7 +287,7 @@ procedure main()
     call printf();
     goto l00000c42;
   l00000c42:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2313bv64), Gamma_R0;
@@ -309,27 +295,27 @@ procedure main()
     call printf();
     goto l00000c62;
   l00000c62:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2329bv64), Gamma_R0;
     R30, Gamma_R30 := 2240bv64, true;
     call printf();
     goto l00000c7b;
   l00000c7b:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2248bv64, true;
     call #free();
     goto l00000c8a;
   l00000c8a:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2256bv64, true;
     call #free();
     goto l00000c98;
   l00000c98:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 8bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     #5, Gamma_#5 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local2/clang_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_pic/malloc_with_local2.expected
@@ -248,52 +248,38 @@ procedure main()
     call malloc();
     goto l00000b92;
   l00000b92:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551600bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
     R8, Gamma_R8 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551596bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
     R0, Gamma_R0 := 4bv64, true;
-    call rely();
-    assert (L(mem, R31) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, R31, R0), gamma_store64(Gamma_mem, R31, Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, R31, R0), gamma_store64(Gamma_stack, R31, Gamma_R0);
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000bbb;
   l00000bbb:
     R8, Gamma_R8 := R0, Gamma_R0;
-    R0, Gamma_R0 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R8);
+    R0, Gamma_R0 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R8);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R8);
     R30, Gamma_R30 := 2148bv64, true;
     call malloc();
     goto l00000be4;
   l00000be4:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R8, Gamma_R8 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2296bv64), Gamma_R0;
@@ -301,7 +287,7 @@ procedure main()
     call printf();
     goto l00000c42;
   l00000c42:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2313bv64), Gamma_R0;
@@ -309,27 +295,27 @@ procedure main()
     call printf();
     goto l00000c62;
   l00000c62:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2329bv64), Gamma_R0;
     R30, Gamma_R30 := 2240bv64, true;
     call printf();
     goto l00000c7b;
   l00000c7b:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2248bv64, true;
     call #free();
     goto l00000c8a;
   l00000c8a:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2256bv64, true;
     call #free();
     goto l00000c98;
   l00000c98:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 8bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     #5, Gamma_#5 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local2/gcc/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc/malloc_with_local2.expected
@@ -330,48 +330,36 @@ procedure main()
     call malloc();
     goto l0000038b;
   l0000038b:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2104bv64, true;
     call malloc();
     goto l000003ac;
   l000003ac:
-    call rely();
-    assert (L(mem, bvadd64(R31, 48bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 48bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 48bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l000003cd;
   l000003cd:
-    call rely();
-    assert (L(mem, bvadd64(R31, 56bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 56bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 56bv64), Gamma_R0);
     R0, Gamma_R0 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 36bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 36bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 36bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -380,7 +368,7 @@ procedure main()
     call printf();
     goto l00000431;
   l00000431:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -389,26 +377,26 @@ procedure main()
     call printf();
     goto l00000457;
   l00000457:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 32bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 32bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2320bv64), Gamma_R0;
     R30, Gamma_R30 := 2224bv64, true;
     call printf();
     goto l00000470;
   l00000470:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2232bv64, true;
     call #free();
     goto l0000047f;
   l0000047f:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R30, Gamma_R30 := 2240bv64, true;
     call #free();
     goto l0000048d;
   l0000048d:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 64bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local2/gcc_O2/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_O2/malloc_with_local2.expected
@@ -16,10 +16,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 2088bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -306,8 +302,8 @@ procedure main()
     goto l00000259;
   l00000259:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local2/gcc_no_plt_no_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_no_plt_no_pic/malloc_with_local2.expected
@@ -330,48 +330,36 @@ procedure main()
     call malloc();
     goto l00000b2d;
   l00000b2d:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2104bv64, true;
     call malloc();
     goto l00000b4e;
   l00000b4e:
-    call rely();
-    assert (L(mem, bvadd64(R31, 48bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 48bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 48bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000b6f;
   l00000b6f:
-    call rely();
-    assert (L(mem, bvadd64(R31, 56bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 56bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 56bv64), Gamma_R0);
     R0, Gamma_R0 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 36bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 36bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 36bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -380,7 +368,7 @@ procedure main()
     call printf();
     goto l00000bd3;
   l00000bd3:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -389,26 +377,26 @@ procedure main()
     call printf();
     goto l00000bf9;
   l00000bf9:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 32bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 32bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2320bv64), Gamma_R0;
     R30, Gamma_R30 := 2224bv64, true;
     call printf();
     goto l00000c12;
   l00000c12:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2232bv64, true;
     call #free();
     goto l00000c21;
   l00000c21:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R30, Gamma_R30 := 2240bv64, true;
     call #free();
     goto l00000c2f;
   l00000c2f:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 64bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local2/gcc_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_pic/malloc_with_local2.expected
@@ -330,48 +330,36 @@ procedure main()
     call malloc();
     goto l00000b2d;
   l00000b2d:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2104bv64, true;
     call malloc();
     goto l00000b4e;
   l00000b4e:
-    call rely();
-    assert (L(mem, bvadd64(R31, 48bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 48bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 48bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000b6f;
   l00000b6f:
-    call rely();
-    assert (L(mem, bvadd64(R31, 56bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 56bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 56bv64), Gamma_R0);
     R0, Gamma_R0 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 36bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 36bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 36bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -380,7 +368,7 @@ procedure main()
     call printf();
     goto l00000bd3;
   l00000bd3:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -389,26 +377,26 @@ procedure main()
     call printf();
     goto l00000bf9;
   l00000bf9:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 32bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 32bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2320bv64), Gamma_R0;
     R30, Gamma_R30 := 2224bv64, true;
     call printf();
     goto l00000c12;
   l00000c12:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2232bv64, true;
     call #free();
     goto l00000c21;
   l00000c21:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R30, Gamma_R30 := 2240bv64, true;
     call #free();
     goto l00000c2f;
   l00000c2f:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 64bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local3/clang/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang/malloc_with_local3.expected
@@ -255,57 +255,43 @@ procedure main()
     call malloc();
     goto l000003e9;
   l000003e9:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551600bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
     R8, Gamma_R8 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551596bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
     R0, Gamma_R0 := 4bv64, true;
-    call rely();
-    assert (L(mem, R31) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, R31, R0), gamma_store64(Gamma_mem, R31, Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, R31, R0), gamma_store64(Gamma_stack, R31, Gamma_R0);
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000412;
   l00000412:
     R8, Gamma_R8 := R0, Gamma_R0;
-    R0, Gamma_R0 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R8);
+    R0, Gamma_R0 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R8);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R8);
     R30, Gamma_R30 := 2148bv64, true;
     call malloc();
     goto l0000043b;
   l0000043b:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R8, Gamma_R8 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2192bv64, true;
     call printCharValue();
     goto l00000504;
   l00000504:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2348bv64), Gamma_R0;
@@ -313,27 +299,27 @@ procedure main()
     call printf();
     goto l00000524;
   l00000524:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2364bv64), Gamma_R0;
     R30, Gamma_R30 := 2228bv64, true;
     call printf();
     goto l0000053d;
   l0000053d:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2236bv64, true;
     call #free();
     goto l0000054c;
   l0000054c:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2244bv64, true;
     call #free();
     goto l0000055a;
   l0000055a:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 8bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     #7, Gamma_#7 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #7), (gamma_load64(Gamma_mem, #7) || L(mem, #7));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#7, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#7, 8bv64)) || L(mem, bvadd64(#7, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #7), gamma_load64(Gamma_stack, #7);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#7, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#7, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }
@@ -341,7 +327,7 @@ procedure main()
 procedure malloc();
 
 procedure printCharValue()
-  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R1, R29, R30, R31, R8, R9, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R1, R29, R30, R31, R8, R9, mem, stack;
   free ensures (Gamma_R29 == old(Gamma_R29));
   free ensures (Gamma_R31 == old(Gamma_R31));
   free ensures (R29 == old(R29));
@@ -359,11 +345,13 @@ procedure printCharValue()
     R29, Gamma_R29 := bvadd64(R31, 16bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
-    R8, Gamma_R8 := zero_extend56_8(memory_load8_le(stack, R9)), gamma_load8(Gamma_stack, R9);
+    R8, Gamma_R8 := zero_extend56_8(memory_load8_le(mem, R9)), (gamma_load8(Gamma_mem, R9) || L(mem, R9));
     R8, Gamma_R8 := zero_extend32_32(bvadd32(R8[32:0], 1bv32)), Gamma_R8;
-    stack, Gamma_stack := memory_store8_le(stack, R9, R8[8:0]), gamma_store8(Gamma_stack, R9, Gamma_R8);
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
     R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
-    R1, Gamma_R1 := zero_extend56_8(memory_load8_le(stack, R8)), gamma_load8(Gamma_stack, R8);
+    R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2391bv64), Gamma_R0;
     R30, Gamma_R30 := 2312bv64, true;
@@ -371,8 +359,8 @@ procedure printCharValue()
     goto l000004e9;
   l000004e9:
     #6, Gamma_#6 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local3/clang_O2/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_O2/malloc_with_local3.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1996bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -230,8 +226,8 @@ procedure main()
     goto l00000370;
   l00000370:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local3/clang_no_plt_no_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_no_plt_no_pic/malloc_with_local3.expected
@@ -255,57 +255,43 @@ procedure main()
     call malloc();
     goto l00000c74;
   l00000c74:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551600bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
     R8, Gamma_R8 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551596bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
     R0, Gamma_R0 := 4bv64, true;
-    call rely();
-    assert (L(mem, R31) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, R31, R0), gamma_store64(Gamma_mem, R31, Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, R31, R0), gamma_store64(Gamma_stack, R31, Gamma_R0);
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000c9d;
   l00000c9d:
     R8, Gamma_R8 := R0, Gamma_R0;
-    R0, Gamma_R0 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R8);
+    R0, Gamma_R0 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R8);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R8);
     R30, Gamma_R30 := 2148bv64, true;
     call malloc();
     goto l00000cc6;
   l00000cc6:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R8, Gamma_R8 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2192bv64, true;
     call printCharValue();
     goto l00000d8f;
   l00000d8f:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2348bv64), Gamma_R0;
@@ -313,27 +299,27 @@ procedure main()
     call printf();
     goto l00000daf;
   l00000daf:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2364bv64), Gamma_R0;
     R30, Gamma_R30 := 2228bv64, true;
     call printf();
     goto l00000dc8;
   l00000dc8:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2236bv64, true;
     call #free();
     goto l00000dd7;
   l00000dd7:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2244bv64, true;
     call #free();
     goto l00000de5;
   l00000de5:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 8bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     #7, Gamma_#7 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #7), (gamma_load64(Gamma_mem, #7) || L(mem, #7));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#7, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#7, 8bv64)) || L(mem, bvadd64(#7, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #7), gamma_load64(Gamma_stack, #7);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#7, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#7, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }
@@ -341,7 +327,7 @@ procedure main()
 procedure malloc();
 
 procedure printCharValue()
-  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R1, R29, R30, R31, R8, R9, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R1, R29, R30, R31, R8, R9, mem, stack;
   free ensures (Gamma_R29 == old(Gamma_R29));
   free ensures (Gamma_R31 == old(Gamma_R31));
   free ensures (R29 == old(R29));
@@ -359,11 +345,13 @@ procedure printCharValue()
     R29, Gamma_R29 := bvadd64(R31, 16bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
-    R8, Gamma_R8 := zero_extend56_8(memory_load8_le(stack, R9)), gamma_load8(Gamma_stack, R9);
+    R8, Gamma_R8 := zero_extend56_8(memory_load8_le(mem, R9)), (gamma_load8(Gamma_mem, R9) || L(mem, R9));
     R8, Gamma_R8 := zero_extend32_32(bvadd32(R8[32:0], 1bv32)), Gamma_R8;
-    stack, Gamma_stack := memory_store8_le(stack, R9, R8[8:0]), gamma_store8(Gamma_stack, R9, Gamma_R8);
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
     R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
-    R1, Gamma_R1 := zero_extend56_8(memory_load8_le(stack, R8)), gamma_load8(Gamma_stack, R8);
+    R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2391bv64), Gamma_R0;
     R30, Gamma_R30 := 2312bv64, true;
@@ -371,8 +359,8 @@ procedure printCharValue()
     goto l00000d74;
   l00000d74:
     #6, Gamma_#6 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local3/clang_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_pic/malloc_with_local3.expected
@@ -255,57 +255,43 @@ procedure main()
     call malloc();
     goto l00000c74;
   l00000c74:
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551600bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R29, 18446744073709551600bv64), R0), gamma_store64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64), Gamma_R0);
     R8, Gamma_R8 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R29, 18446744073709551596bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R29, 18446744073709551596bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R29, 18446744073709551596bv64), Gamma_R8);
     R0, Gamma_R0 := 4bv64, true;
-    call rely();
-    assert (L(mem, R31) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, R31, R0), gamma_store64(Gamma_mem, R31, Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, R31, R0), gamma_store64(Gamma_stack, R31, Gamma_R0);
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000c9d;
   l00000c9d:
     R8, Gamma_R8 := R0, Gamma_R0;
-    R0, Gamma_R0 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R8);
+    R0, Gamma_R0 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 32bv64), R8), gamma_store64(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R8);
     R8, Gamma_R8 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R8);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R8);
     R30, Gamma_R30 := 2148bv64, true;
     call malloc();
     goto l00000cc6;
   l00000cc6:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R8, Gamma_R8 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R8);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R8[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R8);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2192bv64, true;
     call printCharValue();
     goto l00000d8f;
   l00000d8f:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2348bv64), Gamma_R0;
@@ -313,27 +299,27 @@ procedure main()
     call printf();
     goto l00000daf;
   l00000daf:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 28bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 28bv64)) || L(mem, bvadd64(R31, 28bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 28bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 28bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2364bv64), Gamma_R0;
     R30, Gamma_R30 := 2228bv64, true;
     call printf();
     goto l00000dc8;
   l00000dc8:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R29, 18446744073709551600bv64)), (gamma_load64(Gamma_mem, bvadd64(R29, 18446744073709551600bv64)) || L(mem, bvadd64(R29, 18446744073709551600bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R29, 18446744073709551600bv64)), gamma_load64(Gamma_stack, bvadd64(R29, 18446744073709551600bv64));
     R30, Gamma_R30 := 2236bv64, true;
     call #free();
     goto l00000dd7;
   l00000dd7:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 32bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 32bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 32bv64));
     R30, Gamma_R30 := 2244bv64, true;
     call #free();
     goto l00000de5;
   l00000de5:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 8bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 8bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 8bv64));
     #7, Gamma_#7 := bvadd64(R31, 64bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #7), (gamma_load64(Gamma_mem, #7) || L(mem, #7));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#7, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#7, 8bv64)) || L(mem, bvadd64(#7, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #7), gamma_load64(Gamma_stack, #7);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#7, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#7, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 80bv64), Gamma_R31;
     return;
 }
@@ -341,7 +327,7 @@ procedure main()
 procedure malloc();
 
 procedure printCharValue()
-  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R1, R29, R30, R31, R8, R9, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R1, R29, R30, R31, R8, R9, mem, stack;
   free ensures (Gamma_R29 == old(Gamma_R29));
   free ensures (Gamma_R31 == old(Gamma_R31));
   free ensures (R29 == old(R29));
@@ -359,11 +345,13 @@ procedure printCharValue()
     R29, Gamma_R29 := bvadd64(R31, 16bv64), Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
     R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
-    R8, Gamma_R8 := zero_extend56_8(memory_load8_le(stack, R9)), gamma_load8(Gamma_stack, R9);
+    R8, Gamma_R8 := zero_extend56_8(memory_load8_le(mem, R9)), (gamma_load8(Gamma_mem, R9) || L(mem, R9));
     R8, Gamma_R8 := zero_extend32_32(bvadd32(R8[32:0], 1bv32)), Gamma_R8;
-    stack, Gamma_stack := memory_store8_le(stack, R9, R8[8:0]), gamma_store8(Gamma_stack, R9, Gamma_R8);
+    call rely();
+    assert (L(mem, R9) ==> Gamma_R8);
+    mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
     R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
-    R1, Gamma_R1 := zero_extend56_8(memory_load8_le(stack, R8)), gamma_load8(Gamma_stack, R8);
+    R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2391bv64), Gamma_R0;
     R30, Gamma_R30 := 2312bv64, true;
@@ -371,8 +359,8 @@ procedure printCharValue()
     goto l00000d74;
   l00000d74:
     #6, Gamma_#6 := bvadd64(R31, 16bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #6), (gamma_load64(Gamma_mem, #6) || L(mem, #6));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#6, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#6, 8bv64)) || L(mem, bvadd64(#6, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #6), gamma_load64(Gamma_stack, #6);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#6, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#6, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local3/gcc/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc/malloc_with_local3.expected
@@ -335,53 +335,41 @@ procedure main()
     call malloc();
     goto l000003c3;
   l000003c3:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2104bv64, true;
     call malloc();
     goto l000003e4;
   l000003e4:
-    call rely();
-    assert (L(mem, bvadd64(R31, 48bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 48bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 48bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000405;
   l00000405:
-    call rely();
-    assert (L(mem, bvadd64(R31, 56bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 56bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 56bv64), Gamma_R0);
     R0, Gamma_R0 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 36bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 36bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 36bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2168bv64, true;
     call printCharValue();
     goto l000004db;
   l000004db:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -390,26 +378,26 @@ procedure main()
     call printf();
     goto l00000501;
   l00000501:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 32bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 32bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2352bv64), Gamma_R0;
     R30, Gamma_R30 := 2208bv64, true;
     call printf();
     goto l0000051a;
   l0000051a:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2216bv64, true;
     call #free();
     goto l00000529;
   l00000529:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R30, Gamma_R30 := 2224bv64, true;
     call #free();
     goto l00000537;
   l00000537:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 64bv64), Gamma_R31;
     return;
 }
@@ -417,7 +405,7 @@ procedure main()
 procedure malloc();
 
 procedure printCharValue()
-  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R29, R30, R31, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R29, R30, R31, mem, stack;
   free ensures (Gamma_R29 == old(Gamma_R29));
   free ensures (Gamma_R31 == old(Gamma_R31));
   free ensures (R29 == old(R29));
@@ -433,13 +421,15 @@ procedure printCharValue()
     R29, Gamma_R29 := R31, Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(stack, R0)), gamma_load8(Gamma_stack, R0);
+    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R0, Gamma_R0 := zero_extend32_32(bvadd32(R0[32:0], 1bv32)), Gamma_R0;
     R1, Gamma_R1 := zero_extend32_32((0bv24 ++ R0[8:0])), Gamma_R0;
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    stack, Gamma_stack := memory_store8_le(stack, R0, R1[8:0]), gamma_store8(Gamma_stack, R0, Gamma_R1);
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(stack, R0)), gamma_load8(Gamma_stack, R0);
+    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2384bv64), Gamma_R0;
@@ -447,8 +437,8 @@ procedure printCharValue()
     call printf();
     goto l000004c4;
   l000004c4:
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local3/gcc_O2/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_O2/malloc_with_local3.expected
@@ -357,9 +357,9 @@ procedure main()
     goto l000002e0;
   l000002e0:
     R0, Gamma_R0 := 0bv64, true;
-    R19, Gamma_R19 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R19, Gamma_R19 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local3/gcc_no_plt_no_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_no_plt_no_pic/malloc_with_local3.expected
@@ -335,53 +335,41 @@ procedure main()
     call malloc();
     goto l00000c1f;
   l00000c1f:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2104bv64, true;
     call malloc();
     goto l00000c40;
   l00000c40:
-    call rely();
-    assert (L(mem, bvadd64(R31, 48bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 48bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 48bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000c61;
   l00000c61:
-    call rely();
-    assert (L(mem, bvadd64(R31, 56bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 56bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 56bv64), Gamma_R0);
     R0, Gamma_R0 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 36bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 36bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 36bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2168bv64, true;
     call printCharValue();
     goto l00000d37;
   l00000d37:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -390,26 +378,26 @@ procedure main()
     call printf();
     goto l00000d5d;
   l00000d5d:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 32bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 32bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2352bv64), Gamma_R0;
     R30, Gamma_R30 := 2208bv64, true;
     call printf();
     goto l00000d76;
   l00000d76:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2216bv64, true;
     call #free();
     goto l00000d85;
   l00000d85:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R30, Gamma_R30 := 2224bv64, true;
     call #free();
     goto l00000d93;
   l00000d93:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 64bv64), Gamma_R31;
     return;
 }
@@ -417,7 +405,7 @@ procedure main()
 procedure malloc();
 
 procedure printCharValue()
-  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R29, R30, R31, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R29, R30, R31, mem, stack;
   free ensures (Gamma_R29 == old(Gamma_R29));
   free ensures (Gamma_R31 == old(Gamma_R31));
   free ensures (R29 == old(R29));
@@ -433,13 +421,15 @@ procedure printCharValue()
     R29, Gamma_R29 := R31, Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(stack, R0)), gamma_load8(Gamma_stack, R0);
+    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R0, Gamma_R0 := zero_extend32_32(bvadd32(R0[32:0], 1bv32)), Gamma_R0;
     R1, Gamma_R1 := zero_extend32_32((0bv24 ++ R0[8:0])), Gamma_R0;
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    stack, Gamma_stack := memory_store8_le(stack, R0, R1[8:0]), gamma_store8(Gamma_stack, R0, Gamma_R1);
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(stack, R0)), gamma_load8(Gamma_stack, R0);
+    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2384bv64), Gamma_R0;
@@ -447,8 +437,8 @@ procedure printCharValue()
     call printf();
     goto l00000d20;
   l00000d20:
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/malloc_with_local3/gcc_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_pic/malloc_with_local3.expected
@@ -335,53 +335,41 @@ procedure main()
     call malloc();
     goto l00000c1f;
   l00000c1f:
-    call rely();
-    assert (L(mem, bvadd64(R31, 40bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 40bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 40bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 40bv64), Gamma_R0);
     R0, Gamma_R0 := 11bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 28bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 28bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 28bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 28bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2104bv64, true;
     call malloc();
     goto l00000c40;
   l00000c40:
-    call rely();
-    assert (L(mem, bvadd64(R31, 48bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 48bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 48bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 48bv64), Gamma_R0);
     R0, Gamma_R0 := 10bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 32bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 32bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 32bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 32bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2124bv64, true;
     call malloc();
     goto l00000c61;
   l00000c61:
-    call rely();
-    assert (L(mem, bvadd64(R31, 56bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 56bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 56bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 56bv64), Gamma_R0);
     R0, Gamma_R0 := 9bv64, true;
-    call rely();
-    assert (L(mem, bvadd64(R31, 36bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 36bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 36bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 36bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2168bv64, true;
     call printCharValue();
     goto l00000d37;
   l00000d37:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -390,26 +378,26 @@ procedure main()
     call printf();
     goto l00000d5d;
   l00000d5d:
-    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 32bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 32bv64)) || L(mem, bvadd64(R31, 32bv64)));
+    R1, Gamma_R1 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 32bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 32bv64));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2352bv64), Gamma_R0;
     R30, Gamma_R30 := 2208bv64, true;
     call printf();
     goto l00000d76;
   l00000d76:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 40bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 40bv64)) || L(mem, bvadd64(R31, 40bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 40bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 40bv64));
     R30, Gamma_R30 := 2216bv64, true;
     call #free();
     goto l00000d85;
   l00000d85:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 48bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 48bv64)) || L(mem, bvadd64(R31, 48bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 48bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 48bv64));
     R30, Gamma_R30 := 2224bv64, true;
     call #free();
     goto l00000d93;
   l00000d93:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 64bv64), Gamma_R31;
     return;
 }
@@ -417,7 +405,7 @@ procedure main()
 procedure malloc();
 
 procedure printCharValue()
-  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R29, R30, R31, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R29, R30, R31, mem, stack;
   free ensures (Gamma_R29 == old(Gamma_R29));
   free ensures (Gamma_R31 == old(Gamma_R31));
   free ensures (R29 == old(R29));
@@ -433,13 +421,15 @@ procedure printCharValue()
     R29, Gamma_R29 := R31, Gamma_R31;
     stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(stack, R0)), gamma_load8(Gamma_stack, R0);
+    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R0, Gamma_R0 := zero_extend32_32(bvadd32(R0[32:0], 1bv32)), Gamma_R0;
     R1, Gamma_R1 := zero_extend32_32((0bv24 ++ R0[8:0])), Gamma_R0;
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    stack, Gamma_stack := memory_store8_le(stack, R0, R1[8:0]), gamma_store8(Gamma_stack, R0, Gamma_R1);
+    call rely();
+    assert (L(mem, R0) ==> Gamma_R1);
+    mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
     R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
-    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(stack, R0)), gamma_load8(Gamma_stack, R0);
+    R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2384bv64), Gamma_R0;
@@ -447,8 +437,8 @@ procedure printCharValue()
     call printf();
     goto l00000d20;
   l00000d20:
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/multi_malloc/clang/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang/multi_malloc.expected
@@ -221,28 +221,24 @@ procedure main()
     call malloc();
     goto l00000379;
   l00000379:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2112bv64, true;
     call malloc();
     goto l0000038d;
   l0000038d:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2236bv64), Gamma_R0;
@@ -250,7 +246,7 @@ procedure main()
     call printf();
     goto l000003de;
   l000003de:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2253bv64), Gamma_R0;
@@ -258,20 +254,20 @@ procedure main()
     call printf();
     goto l000003fe;
   l000003fe:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2188bv64, true;
     call #free();
     goto l0000040d;
   l0000040d:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2196bv64, true;
     call #free();
     goto l0000041b;
   l0000041b:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 4bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 4bv64)) || L(mem, bvadd64(R31, 4bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 4bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/multi_malloc/clang_O2/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_O2/multi_malloc.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1948bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -190,8 +186,8 @@ procedure main()
     goto l00000329;
   l00000329:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/multi_malloc/clang_no_plt_no_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_no_plt_no_pic/multi_malloc.expected
@@ -221,28 +221,24 @@ procedure main()
     call malloc();
     goto l00000aa7;
   l00000aa7:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2112bv64, true;
     call malloc();
     goto l00000abb;
   l00000abb:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2236bv64), Gamma_R0;
@@ -250,7 +246,7 @@ procedure main()
     call printf();
     goto l00000b0c;
   l00000b0c:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2253bv64), Gamma_R0;
@@ -258,20 +254,20 @@ procedure main()
     call printf();
     goto l00000b2c;
   l00000b2c:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2188bv64, true;
     call #free();
     goto l00000b3b;
   l00000b3b:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2196bv64, true;
     call #free();
     goto l00000b49;
   l00000b49:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 4bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 4bv64)) || L(mem, bvadd64(R31, 4bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 4bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/multi_malloc/clang_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_pic/multi_malloc.expected
@@ -221,28 +221,24 @@ procedure main()
     call malloc();
     goto l00000aa7;
   l00000aa7:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2112bv64, true;
     call malloc();
     goto l00000abb;
   l00000abb:
-    call rely();
-    assert (L(mem, bvadd64(R31, 8bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 8bv64), Gamma_R0);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 8bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 8bv64), Gamma_R0);
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R8, Gamma_R8 := 65bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store8_le(mem, R9, R8[8:0]), gamma_store8(Gamma_mem, R9, Gamma_R8);
-    R9, Gamma_R9 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R9, Gamma_R9 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R8, Gamma_R8 := 42bv64, true;
     call rely();
     assert (L(mem, R9) ==> Gamma_R8);
     mem, Gamma_mem := memory_store32_le(mem, R9, R8[32:0]), gamma_store32(Gamma_mem, R9, Gamma_R8);
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := zero_extend56_8(memory_load8_le(mem, R8)), (gamma_load8(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2236bv64), Gamma_R0;
@@ -250,7 +246,7 @@ procedure main()
     call printf();
     goto l00000b0c;
   l00000b0c:
-    R8, Gamma_R8 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R1, Gamma_R1 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     R0, Gamma_R0 := 0bv64, true;
     R0, Gamma_R0 := bvadd64(R0, 2253bv64), Gamma_R0;
@@ -258,20 +254,20 @@ procedure main()
     call printf();
     goto l00000b2c;
   l00000b2c:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2188bv64, true;
     call #free();
     goto l00000b3b;
   l00000b3b:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R30, Gamma_R30 := 2196bv64, true;
     call #free();
     goto l00000b49;
   l00000b49:
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 4bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 4bv64)) || L(mem, bvadd64(R31, 4bv64)));
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 4bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 4bv64));
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/multi_malloc/gcc/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc/multi_malloc.expected
@@ -303,28 +303,24 @@ procedure main()
     call malloc();
     goto l00000357;
   l00000357:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2096bv64, true;
     call malloc();
     goto l0000036b;
   l0000036b:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -333,7 +329,7 @@ procedure main()
     call printf();
     goto l000003c2;
   l000003c2:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -342,19 +338,19 @@ procedure main()
     call printf();
     goto l000003e8;
   l000003e8:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2180bv64, true;
     call #free();
     goto l000003f7;
   l000003f7:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2188bv64, true;
     call #free();
     goto l00000405;
   l00000405:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/multi_malloc/gcc_O2/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_O2/multi_malloc.expected
@@ -16,10 +16,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 2024bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load64(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 7bv64)] && (gammaMap[bvadd64(index, 6bv64)] && (gammaMap[bvadd64(index, 5bv64)] && (gammaMap[bvadd64(index, 4bv64)] && (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))))))
@@ -271,8 +267,8 @@ procedure main()
     goto l000001fd;
   l000001fd:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 16bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/multi_malloc/gcc_no_plt_no_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_no_plt_no_pic/multi_malloc.expected
@@ -303,28 +303,24 @@ procedure main()
     call malloc();
     goto l00000a64;
   l00000a64:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2096bv64, true;
     call malloc();
     goto l00000a78;
   l00000a78:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -333,7 +329,7 @@ procedure main()
     call printf();
     goto l00000acf;
   l00000acf:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -342,19 +338,19 @@ procedure main()
     call printf();
     goto l00000af5;
   l00000af5:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2180bv64, true;
     call #free();
     goto l00000b04;
   l00000b04:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2188bv64, true;
     call #free();
     goto l00000b12;
   l00000b12:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/multi_malloc/gcc_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_pic/multi_malloc.expected
@@ -303,28 +303,24 @@ procedure main()
     call malloc();
     goto l00000a64;
   l00000a64:
-    call rely();
-    assert (L(mem, bvadd64(R31, 16bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 16bv64), Gamma_R0);
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 16bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 16bv64), Gamma_R0);
     R0, Gamma_R0 := 4bv64, true;
     R30, Gamma_R30 := 2096bv64, true;
     call malloc();
     goto l00000a78;
   l00000a78:
-    call rely();
-    assert (L(mem, bvadd64(R31, 24bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store64_le(mem, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_mem, bvadd64(R31, 24bv64), Gamma_R0);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    stack, Gamma_stack := memory_store64_le(stack, bvadd64(R31, 24bv64), R0), gamma_store64(Gamma_stack, bvadd64(R31, 24bv64), Gamma_R0);
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R1, Gamma_R1 := 65bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store8_le(mem, R0, R1[8:0]), gamma_store8(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R1, Gamma_R1 := 42bv64, true;
     call rely();
     assert (L(mem, R0) ==> Gamma_R1);
     mem, Gamma_mem := memory_store32_le(mem, R0, R1[32:0]), gamma_store32(Gamma_mem, R0, Gamma_R1);
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R0, Gamma_R0 := zero_extend56_8(memory_load8_le(mem, R0)), (gamma_load8(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -333,7 +329,7 @@ procedure main()
     call printf();
     goto l00000acf;
   l00000acf:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, R0)), (gamma_load32(Gamma_mem, R0) || L(mem, R0));
     R1, Gamma_R1 := zero_extend32_32(R0[32:0]), Gamma_R0;
     R0, Gamma_R0 := 0bv64, true;
@@ -342,19 +338,19 @@ procedure main()
     call printf();
     goto l00000af5;
   l00000af5:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 16bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 16bv64)) || L(mem, bvadd64(R31, 16bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 16bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 16bv64));
     R30, Gamma_R30 := 2180bv64, true;
     call #free();
     goto l00000b04;
   l00000b04:
-    R0, Gamma_R0 := memory_load64_le(mem, bvadd64(R31, 24bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 24bv64)) || L(mem, bvadd64(R31, 24bv64)));
+    R0, Gamma_R0 := memory_load64_le(stack, bvadd64(R31, 24bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 24bv64));
     R30, Gamma_R30 := 2188bv64, true;
     call #free();
     goto l00000b12;
   l00000b12:
     R0, Gamma_R0 := 0bv64, true;
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 32bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/syscall/clang/syscall.expected
+++ b/src/test/correct/syscall/clang/syscall.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1944bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
@@ -79,7 +75,7 @@ procedure guarantee_reflexive();
 procedure fork();
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1944bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1945bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1946bv64) == 2bv8);
@@ -170,13 +166,11 @@ procedure main()
     call fork();
     goto l00000317;
   l00000317:
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R0);
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/syscall/clang_no_plt_no_pic/syscall.expected
+++ b/src/test/correct/syscall/clang_no_plt_no_pic/syscall.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1944bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
@@ -79,7 +75,7 @@ procedure guarantee_reflexive();
 procedure fork();
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1944bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1945bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1946bv64) == 2bv8);
@@ -170,13 +166,11 @@ procedure main()
     call fork();
     goto l0000092f;
   l0000092f:
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R0);
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/syscall/clang_pic/syscall.expected
+++ b/src/test/correct/syscall/clang_pic/syscall.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1944bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
@@ -79,7 +75,7 @@ procedure guarantee_reflexive();
 procedure fork();
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1944bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1945bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1946bv64) == 2bv8);
@@ -170,13 +166,11 @@ procedure main()
     call fork();
     goto l0000092f;
   l0000092f:
-    call rely();
-    assert (L(mem, bvadd64(R31, 12bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 12bv64), Gamma_R0);
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 12bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 12bv64)) || L(mem, bvadd64(R31, 12bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 12bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 12bv64), Gamma_R0);
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 12bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 12bv64));
     #5, Gamma_#5 := bvadd64(R31, 32bv64), Gamma_R31;
-    R29, Gamma_R29 := memory_load64_le(mem, #5), (gamma_load64(Gamma_mem, #5) || L(mem, #5));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(#5, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(#5, 8bv64)) || L(mem, bvadd64(#5, 8bv64)));
+    R29, Gamma_R29 := memory_load64_le(stack, #5), gamma_load64(Gamma_stack, #5);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(#5, 8bv64)), gamma_load64(Gamma_stack, bvadd64(#5, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/syscall/gcc/syscall.expected
+++ b/src/test/correct/syscall/gcc/syscall.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1932bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
@@ -79,7 +75,7 @@ procedure guarantee_reflexive();
 procedure fork();
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
@@ -231,12 +227,10 @@ procedure main()
     call fork();
     goto l00000302;
   l00000302:
-    call rely();
-    assert (L(mem, bvadd64(R31, 44bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 44bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 44bv64), Gamma_R0);
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 44bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 44bv64)) || L(mem, bvadd64(R31, 44bv64)));
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 44bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 44bv64), Gamma_R0);
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 44bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 44bv64));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/syscall/gcc_no_plt_no_pic/syscall.expected
+++ b/src/test/correct/syscall/gcc_no_plt_no_pic/syscall.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1932bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
@@ -79,7 +75,7 @@ procedure guarantee_reflexive();
 procedure fork();
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
@@ -231,12 +227,10 @@ procedure main()
     call fork();
     goto l000008f9;
   l000008f9:
-    call rely();
-    assert (L(mem, bvadd64(R31, 44bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 44bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 44bv64), Gamma_R0);
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 44bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 44bv64)) || L(mem, bvadd64(R31, 44bv64)));
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 44bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 44bv64), Gamma_R0);
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 44bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 44bv64));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/correct/syscall/gcc_pic/syscall.expected
+++ b/src/test/correct/syscall/gcc_pic/syscall.expected
@@ -14,10 +14,6 @@ var mem: [bv64]bv8;
 var stack: [bv64]bv8;
 const $_IO_stdin_used_addr: bv64;
 axiom ($_IO_stdin_used_addr == 1932bv64);
-function L(memory: [bv64]bv8, index: bv64) returns (bool) {
-  false
-}
-
 function {:bvbuiltin "bvadd"} bvadd64(bv64, bv64) returns (bv64);
 function gamma_load32(gammaMap: [bv64]bool, index: bv64) returns (bool) {
   (gammaMap[bvadd64(index, 3bv64)] && (gammaMap[bvadd64(index, 2bv64)] && (gammaMap[bvadd64(index, 1bv64)] && gammaMap[index])))
@@ -79,7 +75,7 @@ procedure guarantee_reflexive();
 procedure fork();
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
@@ -231,12 +227,10 @@ procedure main()
     call fork();
     goto l000008f9;
   l000008f9:
-    call rely();
-    assert (L(mem, bvadd64(R31, 44bv64)) ==> Gamma_R0);
-    mem, Gamma_mem := memory_store32_le(mem, bvadd64(R31, 44bv64), R0[32:0]), gamma_store32(Gamma_mem, bvadd64(R31, 44bv64), Gamma_R0);
-    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(mem, bvadd64(R31, 44bv64))), (gamma_load32(Gamma_mem, bvadd64(R31, 44bv64)) || L(mem, bvadd64(R31, 44bv64)));
-    R29, Gamma_R29 := memory_load64_le(mem, R31), (gamma_load64(Gamma_mem, R31) || L(mem, R31));
-    R30, Gamma_R30 := memory_load64_le(mem, bvadd64(R31, 8bv64)), (gamma_load64(Gamma_mem, bvadd64(R31, 8bv64)) || L(mem, bvadd64(R31, 8bv64)));
+    stack, Gamma_stack := memory_store32_le(stack, bvadd64(R31, 44bv64), R0[32:0]), gamma_store32(Gamma_stack, bvadd64(R31, 44bv64), Gamma_R0);
+    R0, Gamma_R0 := zero_extend32_32(memory_load32_le(stack, bvadd64(R31, 44bv64))), gamma_load32(Gamma_stack, bvadd64(R31, 44bv64));
+    R29, Gamma_R29 := memory_load64_le(stack, R31), gamma_load64(Gamma_stack, R31);
+    R30, Gamma_R30 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
     R31, Gamma_R31 := bvadd64(R31, 48bv64), Gamma_R31;
     return;
 }

--- a/src/test/incorrect/nestedifglobal/clang_pic/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/clang_pic/nestedifglobal.expected
@@ -227,7 +227,7 @@ procedure main()
     goto l000003b9;
   l000003b9:
     R8, Gamma_R8 := memory_load64_le(stack, bvadd64(R31, 8bv64)), gamma_load64(Gamma_stack, bvadd64(R31, 8bv64));
-    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(stack, R8)), gamma_load32(Gamma_stack, R8);
+    R8, Gamma_R8 := zero_extend32_32(memory_load32_le(mem, R8)), (gamma_load32(Gamma_mem, R8) || L(mem, R8));
     #5, Gamma_#5 := bvadd32(R8[32:0], 4294967294bv32), Gamma_R8;
     VF, Gamma_VF := bvnot1(bvcomp33(sign_extend1_32(bvadd32(#5, 1bv32)), bvadd33(sign_extend1_32(R8[32:0]), 8589934591bv33))), (Gamma_R8 && Gamma_#5);
     CF, Gamma_CF := bvnot1(bvcomp33(zero_extend1_32(bvadd32(#5, 1bv32)), bvadd33(zero_extend1_32(R8[32:0]), 4294967295bv33))), (Gamma_R8 && Gamma_#5);


### PR DESCRIPTION
Fixes #100

There were two problems with my previous implementation: not traversing to the returnTarget of calls, and counting the rhs of an assignment as a stack value if it contained a stack reference inside a load index or store.