### PR TITLE
Add version output cli flag derived from git

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import scala.io.Source
 
+import scala.sys.process.*
 ThisBuild / scalaVersion := "3.1.0"
-ThisBuild / version := "0.0.1"
 ThisBuild / organization := "uq.pac"
 
 val javaTests = "com.novocode" % "junit-interface" % "0.11" % "test"
@@ -13,9 +13,10 @@ val mainArgs = "com.lihaoyi" %% "mainargs" % "0.5.1"
 
 lazy val root = project
   .in(file("."))
-  .enablePlugins(Antlr4Plugin)
+  .enablePlugins(Antlr4Plugin, BuildInfoPlugin)
   .settings(
     name := "wptool-boogie",
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     Antlr4 / antlr4Version := "4.9.3",
     Antlr4 / antlr4GenVisitor := true,
     Antlr4 / antlr4PackageName := Some("Parsers"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,7 @@
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
+
+resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
+
+addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.6.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -4,6 +4,7 @@ import bap._
 import boogie._
 import translating._
 import util.RunUtils
+import buildinfo.* 
 
 import scala.collection.mutable.{ArrayBuffer, Set}
 import scala.collection.{immutable, mutable}
@@ -14,18 +15,20 @@ import mainargs.{main, arg, ParserForClass, Flag}
 
 object Main {
 
-  @main(name = "BASIL")
+  @main(name = f"${BuildInfo.name} ${BuildInfo.version}")
   case class Config(
       @arg(name = "adt", short = 'a', doc = "BAP ADT file name.")
-      adtFileName: String,
+      adtFileName: String = "",
       @arg(name = "relf", short = 'r', doc = "Name of the file containing the output of 'readelf -s -r -W'.")
-      relfFileName: String,
+      relfFileName: String = "",
       @arg(name = "spec", short = 's', doc = "BASIL specification file.")
       specFileName: Option[String],
       @arg(name = "output", short = 'o', doc = "Boogie output destination file.")
       outFileName: String = "boogie_out.bpl",
       @arg(name = "verbose", short = 'v', doc = "Show extra debugging logs.")
       verbose: Flag,
+      @arg(name = "version", doc = "Show version.")
+      version: Flag,
       @arg(name = "analyse", doc = "Run static analysis pass.")
       analyse: Flag,
       @arg(name = "interpret", doc = "Run BASIL IL interpreter.")
@@ -48,13 +51,27 @@ object Main {
       }
     }
 
+
     if (conf.help.value) {
       println(parser.helpText(sorted = false));
+      return;
     }
+
+    if (conf.version.value) {
+      println(f"${BuildInfo.name} ${BuildInfo.version}")
+      return;
+    }
+
 
     Logger.setLevel(LogLevel.INFO)
     if (conf.verbose.value) {
       Logger.setLevel(LogLevel.DEBUG)
+    }
+
+    if (conf.adtFileName == "" || conf.relfFileName == "") {
+      println("Must specify adt and relf.")
+      println(parser.helpText(sorted = false));
+      return;
     }
 
     val program: BProgram = RunUtils.loadAndTranslate(


### PR DESCRIPTION
For  #85

A bit silly that this adds two new sbt plugins but I couldn't figure out a nice way to pass the version string from SBT to Scala, Brendan's suggestion didn't seem to work. 

This git plugin is nice since it appends the git hash to the tagged version and adds a flag if its been modified since checkout. E.g. `wptool-boogie 0.1.1-alpha-65-8914893e-SNAPSHOT`

