### PR TITLE
Propagate modifies clause through boogie program

### DIFF
--- a/examples/simplified_http_parse_basic/example.spec
+++ b/examples/simplified_http_parse_basic/example.spec
@@ -8,11 +8,11 @@ DIRECT functions: gamma_load64, gamma_load8, memory_load8_le, bvult64, bvule64, 
 
   
 Subroutine: #free
-  Requires DIRECT: "gamma_load8(Gamma_mem, bvadd64(R0, 0bv64)) == true";
-  Requires DIRECT: "gamma_load8(Gamma_mem, bvadd64(R0, 1bv64)) == true";
-  Requires DIRECT: "gamma_load8(Gamma_mem, bvadd64(R0, 2bv64)) == true";
-  Requires DIRECT: "gamma_load8(Gamma_mem, bvadd64(R0, 3bv64)) == true";
-Ensures DIRECT: "Gamma_R0 == true"
+  Requires DIRECT: "gamma_load8(Gamma_mem, bvadd64(R0, 0bv64)) == true"
+  Requires DIRECT: "gamma_load8(Gamma_mem, bvadd64(R0, 1bv64)) == true"
+  Requires DIRECT: "gamma_load8(Gamma_mem, bvadd64(R0, 2bv64)) == true"
+  Requires DIRECT: "gamma_load8(Gamma_mem, bvadd64(R0, 3bv64)) == true"
+  Ensures DIRECT: "Gamma_R0 == true"
 
 
 Subroutine: main

--- a/src/main/scala/boogie/BCmd.scala
+++ b/src/main/scala/boogie/BCmd.scala
@@ -39,7 +39,7 @@ case class BAssume(body: BExpr, comment: Option[String] = None) extends BCmd {
   override def globals: Set[BVar] = body.globals
 }
 
-case class ProcedureCall(name: String, lhss: Seq[BVar], params: Seq[BExpr], comment: Option[String] = None) extends BCmd {
+case class BProcedureCall(name: String, lhss: Seq[BVar], params: Seq[BExpr], comment: Option[String] = None) extends BCmd {
   override def toString: String = {
     if (lhss.isEmpty) {
       s"call $name();"

--- a/src/main/scala/boogie/BProgram.scala
+++ b/src/main/scala/boogie/BProgram.scala
@@ -18,7 +18,7 @@ case class BProcedure(
     requiresDirect: List[String],
     freeEnsures: List[BExpr],
     freeRequires: List[BExpr],
-    modifies: Seq[BVar],
+    modifies: Set[BVar],
     body: List[BCmdOrBlock]
 ) extends BDeclaration
     with Ordered[BProcedure] {
@@ -32,7 +32,7 @@ case class BProcedure(
     }
     val semicolon = if body.nonEmpty then "" else ";"
     val modifiesStr = if (modifies.nonEmpty) {
-      List(s"  modifies ${modifies.mkString(", ")};")
+      List(s"  modifies ${modifies.toSeq.sorted.mkString(", ")};")
     } else {
       List()
     }

--- a/src/main/scala/translating/IRToBoogie.scala
+++ b/src/main/scala/translating/IRToBoogie.scala
@@ -52,7 +52,7 @@ class IRToBoogie(var program: Program, var spec: Specification) {
       List(),
       List(),
       List(),
-      Seq(mem, Gamma_mem),
+      Set(mem, Gamma_mem),
       guaranteesReflexive.map(g => BAssert(g))
     )
 
@@ -82,9 +82,9 @@ class IRToBoogie(var program: Program, var spec: Specification) {
     } else {
       reliesUsed
     }
-    val relyProc = BProcedure("rely", List(), List(), relyEnsures, List(), List(), List(), readOnlyMemory, List(), Seq(mem, Gamma_mem), List())
-    val relyTransitive = BProcedure("rely_transitive", List(), List(), reliesUsed, List(), List(), List(), List(), List(), Seq(mem, Gamma_mem), List(BProcedureCall("rely", List(), List()), BProcedureCall("rely", List(), List())))
-    val relyReflexive = BProcedure("rely_reflexive", List(), List(), List(), List(), List(), List(), List(), List(), Seq(), reliesReflexive.map(r => BAssert(r)))
+    val relyProc = BProcedure("rely", List(), List(), relyEnsures, List(), List(), List(), readOnlyMemory, List(), Set(mem, Gamma_mem), List())
+    val relyTransitive = BProcedure("rely_transitive", List(), List(), reliesUsed, List(), List(), List(), List(), List(), Set(mem, Gamma_mem), List(BProcedureCall("rely", List(), List()), BProcedureCall("rely", List(), List())))
+    val relyReflexive = BProcedure("rely_reflexive", List(), List(), List(), List(), List(), List(), List(), List(), Set(), reliesReflexive.map(r => BAssert(r)))
     List(relyProc, relyTransitive, relyReflexive)
   }
 
@@ -234,8 +234,8 @@ class IRToBoogie(var program: Program, var spec: Specification) {
           case c: BCmd => Seq(c)
         }
 
-        val modifies: Seq[BVar] = (procedure.modifies ++ (cmds.collect{ case x: BProcedureCall => (procedures.find(_.name == x.name))})
-          .flatten.flatMap(_.modifies)).distinct
+        val modifies: Set[BVar] = procedure.modifies ++ cmds.collect{ case x: BProcedureCall => procedures.find(_.name == x.name)}
+          .flatten.flatMap(_.modifies)
 
         if (procedure.modifies != procedure.modifies)
           changed = true
@@ -287,7 +287,7 @@ class IRToBoogie(var program: Program, var spec: Specification) {
       procRequiresDirect,
       freeEnsures,
       freeRequires,
-      modifies,
+      modifies.toSet,
       body.toList
     )
   }

--- a/src/main/scala/translating/IRToBoogie.scala
+++ b/src/main/scala/translating/IRToBoogie.scala
@@ -64,7 +64,7 @@ class IRToBoogie(var program: Program, var spec: Specification) {
     val functionsUsed3 = functionsUsed2.flatMap(p => p.functionOps).map(p => functionOpToDefinition(p))
     val functionsUsed = (functionsUsed2 ++ functionsUsed3).toList.sorted
 
-    val declarations = globalDecls ++ globalConsts ++ functionsUsed ++ rgProcs ++ procedures
+    val declarations = globalDecls ++ globalConsts ++ functionsUsed ++ pushUpModifiesFixedPoint(rgProcs ++ procedures)
     BProgram(declarations)
   }
 
@@ -83,7 +83,7 @@ class IRToBoogie(var program: Program, var spec: Specification) {
       reliesUsed
     }
     val relyProc = BProcedure("rely", List(), List(), relyEnsures, List(), List(), List(), readOnlyMemory, List(), Seq(mem, Gamma_mem), List())
-    val relyTransitive = BProcedure("rely_transitive", List(), List(), reliesUsed, List(), List(), List(), List(), List(), Seq(mem, Gamma_mem), List(ProcedureCall("rely", List(), List()), ProcedureCall("rely", List(), List())))
+    val relyTransitive = BProcedure("rely_transitive", List(), List(), reliesUsed, List(), List(), List(), List(), List(), Seq(mem, Gamma_mem), List(BProcedureCall("rely", List(), List()), BProcedureCall("rely", List(), List())))
     val relyReflexive = BProcedure("rely_reflexive", List(), List(), List(), List(), List(), List(), List(), List(), Seq(), reliesReflexive.map(r => BAssert(r)))
     List(relyProc, relyTransitive, relyReflexive)
   }
@@ -217,14 +217,48 @@ class IRToBoogie(var program: Program, var spec: Specification) {
     }
   }
 
+  def pushUpModifiesFixedPoint(procedures: List[BProcedure]): List[BProcedure] = {
+    pushUpModifies(procedures) match {
+      case (true, proc) => pushUpModifiesFixedPoint(proc)
+      case (false, proc) => proc
+    }
+  }
+
+  def pushUpModifies(procedures: List[BProcedure]): (Boolean, List[BProcedure]) = {
+    var changed = false
+
+    val procs: List[BProcedure] = procedures.map(
+      procedure => {
+        val cmds: List[BCmd] = procedure.body.flatten {
+          case b: BBlock => b.body
+          case c: BCmd => Seq(c)
+        }
+
+        val modifies: Seq[BVar] = (procedure.modifies ++ (cmds.collect{ case x: BProcedureCall => (procedures.find(_.name == x.name))})
+          .flatten.flatMap(_.modifies)).distinct
+
+        if (procedure.modifies != procedure.modifies)
+          changed = true
+
+        procedure.copy(modifies = modifies)
+      }
+    )
+    (changed, procs)
+  }
+
+
   def translateProcedure(p: Procedure, readOnlyMemory: List[BExpr]): BProcedure = {
     val body = p.blocks.map(b => translateBlock(b))
-    // TODO don't hardcode Seq(mem, Gamma_mem) but this is necessary to work with adding rely() calls for now
-    val modifies: Seq[BVar] = {Seq(mem, Gamma_mem) ++ p.modifies
+
+    val callsRely: Boolean = body.flatten(_.body).exists(_ match
+      case BProcedureCall("rely", lhs, params, comment) => true
+      case _ => false)
+
+    val modifies: Seq[BVar] = p.modifies.toSeq
       .flatMap {
         case m: Memory   => Seq(m.toBoogie, m.toGamma)
         case r: Register => Seq(r.toBoogie, r.toGamma)
-      }}.distinct.sorted
+      }.distinct.sorted
 
     val modifiedPreserve = modifies.collect { case m: BVar if modifiedCheck.contains(m) => m }
     val modifiedPreserveEnsures: List[BExpr] = modifiedPreserve.map(m => BinaryBExpr(BoolEQ, m, Old(m))).toList
@@ -278,7 +312,7 @@ class IRToBoogie(var program: Program, var spec: Specification) {
 
   def translate(j: Jump): List[BCmd] = j match {
     case d: DirectCall =>
-      val call = List(ProcedureCall(d.target.name, List(), List()))
+      val call = List(BProcedureCall(d.target.name, List(), List()))
       val returnTarget = d.returnTarget match {
         case Some(r) => List(GoToCmd(r.label))
         case None    => List(Comment("no return target"), BAssume(FalseBLiteral))
@@ -331,7 +365,7 @@ class IRToBoogie(var program: Program, var spec: Specification) {
       if (lhs == stack) {
         List(store)
       } else {
-        val rely = ProcedureCall("rely", List(), List())
+        val rely = BProcedureCall("rely", List(), List())
         val gammaValueCheck = BAssert(BinaryBExpr(BoolIMPLIES, L(lhs, rhs.index), m.rhs.value.toGamma))
         val oldAssigns =
           guaranteeOldVars.map(g => AssignCmd(g.toOldVar, BMemoryLoad(lhs, g.toAddrVar, Endian.LittleEndian, g.size)))
@@ -365,7 +399,7 @@ class IRToBoogie(var program: Program, var spec: Specification) {
         List(assign)
       } else {
         val memories = loads.map(m => m.memory).toSeq.sorted
-        List(ProcedureCall("rely", Seq(), Seq()), assign)
+        List(BProcedureCall("rely", Seq(), Seq()), assign)
       }
     case a: Assert =>
       val body = a.body.toBoogie

--- a/src/test/correct/arrays_simple/clang/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang/arrays_simple.expected
@@ -33,7 +33,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1872bv64) == 1bv8);
@@ -74,7 +74,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -85,7 +85,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/arrays_simple/clang/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang/arrays_simple.expected
@@ -88,7 +88,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/arrays_simple/clang_O2/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang_O2/arrays_simple.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1840bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/arrays_simple/clang_O2/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang_O2/arrays_simple.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/arrays_simple/clang_no_plt_no_pic/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang_no_plt_no_pic/arrays_simple.expected
@@ -33,7 +33,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1872bv64) == 1bv8);
@@ -74,7 +74,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -85,7 +85,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/arrays_simple/clang_no_plt_no_pic/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang_no_plt_no_pic/arrays_simple.expected
@@ -88,7 +88,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/arrays_simple/clang_pic/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang_pic/arrays_simple.expected
@@ -33,7 +33,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1872bv64) == 1bv8);
@@ -74,7 +74,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -85,7 +85,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/arrays_simple/clang_pic/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/clang_pic/arrays_simple.expected
@@ -88,7 +88,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/arrays_simple/gcc_O2/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/gcc_O2/arrays_simple.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/arrays_simple/gcc_O2/arrays_simple.expected
+++ b/src/test/correct/arrays_simple/gcc_O2/arrays_simple.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_arrays_read/clang/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/clang/basic_arrays_read.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert true;
 }

--- a/src/test/correct/basic_arrays_read/clang_O2/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/clang_O2/basic_arrays_read.expected
@@ -28,7 +28,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
   free ensures (memory_load8_le(mem, 1848bv64) == 1bv8);
@@ -69,7 +69,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 {
   call rely();
@@ -82,7 +82,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert true;
 }

--- a/src/test/correct/basic_arrays_read/clang_no_plt_no_pic/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/clang_no_plt_no_pic/basic_arrays_read.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert true;
 }

--- a/src/test/correct/basic_arrays_read/clang_pic/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/clang_pic/basic_arrays_read.expected
@@ -45,7 +45,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
   free ensures (memory_load8_le(mem, 1928bv64) == 1bv8);
@@ -94,7 +94,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 {
   call rely();
@@ -107,7 +107,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert true;
 }

--- a/src/test/correct/basic_arrays_read/gcc/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/gcc/basic_arrays_read.expected
@@ -31,7 +31,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -72,7 +72,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 {
   call rely();
@@ -85,7 +85,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert true;
 }

--- a/src/test/correct/basic_arrays_read/gcc_O2/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/gcc_O2/basic_arrays_read.expected
@@ -28,7 +28,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -69,7 +69,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 {
   call rely();
@@ -82,7 +82,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert true;
 }

--- a/src/test/correct/basic_arrays_read/gcc_no_plt_no_pic/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/gcc_no_plt_no_pic/basic_arrays_read.expected
@@ -31,7 +31,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -72,7 +72,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 {
   call rely();
@@ -85,7 +85,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert true;
 }

--- a/src/test/correct/basic_arrays_read/gcc_pic/basic_arrays_read.expected
+++ b/src/test/correct/basic_arrays_read/gcc_pic/basic_arrays_read.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
   free ensures (memory_load8_le(mem, 1924bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, bvadd64($arr_addr, 0bv64))) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 {
   call rely();
@@ -101,7 +101,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert true;
 }

--- a/src/test/correct/basic_arrays_write/clang/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/clang/basic_arrays_write.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures true;
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures true;
 {
   call rely();
@@ -93,7 +93,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 }

--- a/src/test/correct/basic_arrays_write/clang_O2/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/clang_O2/basic_arrays_write.expected
@@ -31,7 +31,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures true;
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -72,7 +72,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures true;
 {
   call rely();
@@ -85,7 +85,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 }

--- a/src/test/correct/basic_arrays_write/clang_no_plt_no_pic/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/clang_no_plt_no_pic/basic_arrays_write.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures true;
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures true;
 {
   call rely();
@@ -93,7 +93,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 }

--- a/src/test/correct/basic_arrays_write/clang_pic/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/clang_pic/basic_arrays_write.expected
@@ -47,7 +47,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures true;
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -96,7 +96,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures true;
 {
   call rely();
@@ -109,7 +109,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 }

--- a/src/test/correct/basic_arrays_write/gcc/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/gcc/basic_arrays_write.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures true;
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures true;
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 }

--- a/src/test/correct/basic_arrays_write/gcc_O2/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/gcc_O2/basic_arrays_write.expected
@@ -31,7 +31,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures true;
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -72,7 +72,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures true;
 {
   call rely();
@@ -85,7 +85,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 }

--- a/src/test/correct/basic_arrays_write/gcc_no_plt_no_pic/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/gcc_no_plt_no_pic/basic_arrays_write.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures true;
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures true;
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 }

--- a/src/test/correct/basic_arrays_write/gcc_pic/basic_arrays_write.expected
+++ b/src/test/correct/basic_arrays_write/gcc_pic/basic_arrays_write.expected
@@ -45,7 +45,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures true;
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -94,7 +94,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures true;
 {
   call rely();
@@ -107,7 +107,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, bvadd64($arr_addr, 0bv64)) == memory_load32_le(mem, bvadd64($arr_addr, 0bv64)));
 }

--- a/src/test/correct/basic_assign_assign/clang/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/clang/basic_assign_assign.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
 }

--- a/src/test/correct/basic_assign_assign/clang_O2/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/clang_O2/basic_assign_assign.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
 }

--- a/src/test/correct/basic_assign_assign/clang_no_plt_no_pic/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/clang_no_plt_no_pic/basic_assign_assign.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
 }

--- a/src/test/correct/basic_assign_assign/clang_pic/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/clang_pic/basic_assign_assign.expected
@@ -38,7 +38,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -87,7 +87,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 {
   call rely();
@@ -100,7 +100,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
 }

--- a/src/test/correct/basic_assign_assign/gcc/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/gcc/basic_assign_assign.expected
@@ -28,7 +28,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -69,7 +69,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 {
   call rely();
@@ -82,7 +82,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
 }

--- a/src/test/correct/basic_assign_assign/gcc_O2/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/gcc_O2/basic_assign_assign.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
 }

--- a/src/test/correct/basic_assign_assign/gcc_no_plt_no_pic/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/gcc_no_plt_no_pic/basic_assign_assign.expected
@@ -28,7 +28,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -69,7 +69,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 {
   call rely();
@@ -82,7 +82,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
 }

--- a/src/test/correct/basic_assign_assign/gcc_pic/basic_assign_assign.expected
+++ b/src/test/correct/basic_assign_assign/gcc_pic/basic_assign_assign.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -85,7 +85,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 {
   call rely();
@@ -98,7 +98,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 5bv32));
 }

--- a/src/test/correct/basic_assign_increment/clang/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/clang/basic_assign_increment.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 }

--- a/src/test/correct/basic_assign_increment/clang_O2/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/clang_O2/basic_assign_increment.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 }

--- a/src/test/correct/basic_assign_increment/clang_no_plt_no_pic/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/clang_no_plt_no_pic/basic_assign_increment.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 }

--- a/src/test/correct/basic_assign_increment/clang_pic/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/clang_pic/basic_assign_increment.expected
@@ -44,7 +44,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
   free ensures (memory_load8_le(mem, 1924bv64) == 1bv8);
@@ -93,7 +93,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
 {
   call rely();
@@ -106,7 +106,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 }

--- a/src/test/correct/basic_assign_increment/gcc/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/gcc/basic_assign_increment.expected
@@ -34,7 +34,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -75,7 +75,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
 {
   call rely();
@@ -88,7 +88,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 }

--- a/src/test/correct/basic_assign_increment/gcc_O2/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/gcc_O2/basic_assign_increment.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 }

--- a/src/test/correct/basic_assign_increment/gcc_no_plt_no_pic/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/gcc_no_plt_no_pic/basic_assign_increment.expected
@@ -34,7 +34,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -75,7 +75,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
 {
   call rely();
@@ -88,7 +88,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 }

--- a/src/test/correct/basic_assign_increment/gcc_pic/basic_assign_increment.expected
+++ b/src/test/correct/basic_assign_increment/gcc_pic/basic_assign_increment.expected
@@ -42,7 +42,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -91,7 +91,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (memory_load32_le(mem, $x_addr) == 5bv32));
 {
   call rely();
@@ -104,7 +104,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || (memory_load32_le(mem, $x_addr) == 1bv32)) || (memory_load32_le(mem, $x_addr) == 6bv32));
 }

--- a/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
@@ -61,7 +61,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
@@ -103,7 +103,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
@@ -118,7 +118,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));

--- a/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang/basic_function_call_caller.expected
@@ -265,7 +265,7 @@ procedure main()
 }
 
 procedure zero()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1896bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1897bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1898bv64) == 2bv8);

--- a/src/test/correct/basic_function_call_caller/clang_O2/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_O2/basic_function_call_caller.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
@@ -81,7 +81,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
@@ -96,7 +96,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));

--- a/src/test/correct/basic_function_call_caller/clang_no_plt_no_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_no_plt_no_pic/basic_function_call_caller.expected
@@ -61,7 +61,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
@@ -103,7 +103,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
@@ -118,7 +118,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));

--- a/src/test/correct/basic_function_call_caller/clang_no_plt_no_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_no_plt_no_pic/basic_function_call_caller.expected
@@ -265,7 +265,7 @@ procedure main()
 }
 
 procedure zero()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1896bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1897bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1898bv64) == 2bv8);

--- a/src/test/correct/basic_function_call_caller/clang_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_pic/basic_function_call_caller.expected
@@ -61,7 +61,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
@@ -119,7 +119,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
@@ -134,7 +134,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));

--- a/src/test/correct/basic_function_call_caller/clang_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/clang_pic/basic_function_call_caller.expected
@@ -317,7 +317,7 @@ procedure main()
 }
 
 procedure zero()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1968bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1969bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1970bv64) == 2bv8);

--- a/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
@@ -263,7 +263,7 @@ procedure main()
 }
 
 procedure zero()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1900bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1901bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1902bv64) == 2bv8);

--- a/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc/basic_function_call_caller.expected
@@ -59,7 +59,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
@@ -101,7 +101,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
@@ -116,7 +116,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));

--- a/src/test/correct/basic_function_call_caller/gcc_O2/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_O2/basic_function_call_caller.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
@@ -81,7 +81,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
@@ -96,7 +96,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));

--- a/src/test/correct/basic_function_call_caller/gcc_no_plt_no_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_no_plt_no_pic/basic_function_call_caller.expected
@@ -263,7 +263,7 @@ procedure main()
 }
 
 procedure zero()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1900bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1901bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1902bv64) == 2bv8);

--- a/src/test/correct/basic_function_call_caller/gcc_no_plt_no_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_no_plt_no_pic/basic_function_call_caller.expected
@@ -59,7 +59,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
@@ -101,7 +101,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
@@ -116,7 +116,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));

--- a/src/test/correct/basic_function_call_caller/gcc_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_pic/basic_function_call_caller.expected
@@ -59,7 +59,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
@@ -117,7 +117,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
@@ -132,7 +132,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   assert (gamma_load32(Gamma_mem, $y_addr) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));

--- a/src/test/correct/basic_function_call_caller/gcc_pic/basic_function_call_caller.expected
+++ b/src/test/correct/basic_function_call_caller/gcc_pic/basic_function_call_caller.expected
@@ -313,7 +313,7 @@ procedure main()
 }
 
 procedure zero()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1964bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1965bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1966bv64) == 2bv8);

--- a/src/test/correct/basic_function_call_reader/clang/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang/basic_function_call_reader.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
@@ -89,7 +89,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
 {
@@ -104,14 +104,14 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/clang/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang/basic_function_call_reader.expected
@@ -111,7 +111,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/clang_O2/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_O2/basic_function_call_reader.expected
@@ -37,7 +37,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
@@ -79,7 +79,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
 {
@@ -94,14 +94,14 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, Gamma_R9, R0, R8, R9, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/clang_O2/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_O2/basic_function_call_reader.expected
@@ -101,7 +101,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, R0, R8, R9, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/clang_no_plt_no_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_no_plt_no_pic/basic_function_call_reader.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
@@ -89,7 +89,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
 {
@@ -104,14 +104,14 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/clang_no_plt_no_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_no_plt_no_pic/basic_function_call_reader.expected
@@ -111,7 +111,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/clang_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_pic/basic_function_call_reader.expected
@@ -135,7 +135,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/clang_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/clang_pic/basic_function_call_reader.expected
@@ -55,7 +55,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
@@ -113,7 +113,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
 {
@@ -128,14 +128,14 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/gcc/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc/basic_function_call_reader.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
@@ -87,7 +87,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
 {
@@ -102,14 +102,14 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/gcc/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc/basic_function_call_reader.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/gcc_O2/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_O2/basic_function_call_reader.expected
@@ -92,7 +92,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
+  modifies Gamma_R0, Gamma_R1, R0, R1, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/gcc_O2/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_O2/basic_function_call_reader.expected
@@ -28,7 +28,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
@@ -70,7 +70,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
 {
@@ -85,14 +85,14 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, R0, R1, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/gcc_no_plt_no_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_no_plt_no_pic/basic_function_call_reader.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
@@ -87,7 +87,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
 {
@@ -102,14 +102,14 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/gcc_no_plt_no_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_no_plt_no_pic/basic_function_call_reader.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/gcc_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_pic/basic_function_call_reader.expected
@@ -53,7 +53,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
@@ -111,7 +111,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == 0bv32) ==> (memory_load32_le(mem, $x_addr) == 0bv32));
   ensures (old(gamma_load32(Gamma_mem, $y_addr)) ==> ((memory_load32_le(mem, $x_addr) == 0bv32) || gamma_load32(Gamma_mem, $y_addr)));
 {
@@ -126,14 +126,14 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_function_call_reader/gcc_pic/basic_function_call_reader.expected
+++ b/src/test/correct/basic_function_call_reader/gcc_pic/basic_function_call_reader.expected
@@ -133,7 +133,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_read/clang/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/clang/basic_lock_read.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1900bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -101,7 +101,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/basic_lock_read/clang_O2/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/clang_O2/basic_lock_read.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/basic_lock_read/clang_no_plt_no_pic/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/clang_no_plt_no_pic/basic_lock_read.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1900bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -101,7 +101,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/basic_lock_read/clang_pic/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/clang_pic/basic_lock_read.expected
@@ -55,7 +55,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1972bv64) == 1bv8);
@@ -112,7 +112,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -125,7 +125,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/basic_lock_read/gcc/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/gcc/basic_lock_read.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1900bv64) == 1bv8);
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -99,7 +99,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/basic_lock_read/gcc_O2/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/gcc_O2/basic_lock_read.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/basic_lock_read/gcc_no_plt_no_pic/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/gcc_no_plt_no_pic/basic_lock_read.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1900bv64) == 1bv8);
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -99,7 +99,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/basic_lock_read/gcc_pic/basic_lock_read.expected
+++ b/src/test/correct/basic_lock_read/gcc_pic/basic_lock_read.expected
@@ -53,7 +53,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -110,7 +110,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -123,7 +123,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/basic_lock_security_read/clang/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang/basic_lock_security_read.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -101,13 +101,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/clang/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang/basic_lock_security_read.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/clang_O2/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_O2/basic_lock_security_read.expected
@@ -97,7 +97,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, R0, R8, R9, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/clang_O2/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_O2/basic_lock_security_read.expected
@@ -37,7 +37,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -91,13 +91,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, Gamma_R9, R0, R8, R9, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/clang_no_plt_no_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_no_plt_no_pic/basic_lock_security_read.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -101,13 +101,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/clang_no_plt_no_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_no_plt_no_pic/basic_lock_security_read.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/clang_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_pic/basic_lock_security_read.expected
@@ -55,7 +55,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1968bv64) == 1bv8);
@@ -112,7 +112,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -125,13 +125,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/clang_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/clang_pic/basic_lock_security_read.expected
@@ -131,7 +131,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/gcc/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc/basic_lock_security_read.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1888bv64) == 1bv8);
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -99,13 +99,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/gcc/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc/basic_lock_security_read.expected
@@ -105,7 +105,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/gcc_O2/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_O2/basic_lock_security_read.expected
@@ -31,7 +31,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -72,7 +72,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -85,13 +85,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R2, R0, R1, R2, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/gcc_O2/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_O2/basic_lock_security_read.expected
@@ -91,7 +91,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;
+  modifies Gamma_R0, Gamma_R1, Gamma_R2, R0, R1, R2, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/gcc_no_plt_no_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_no_plt_no_pic/basic_lock_security_read.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1888bv64) == 1bv8);
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -99,13 +99,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/gcc_no_plt_no_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_no_plt_no_pic/basic_lock_security_read.expected
@@ -105,7 +105,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/gcc_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_pic/basic_lock_security_read.expected
@@ -129,7 +129,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_read/gcc_pic/basic_lock_security_read.expected
+++ b/src/test/correct/basic_lock_security_read/gcc_pic/basic_lock_security_read.expected
@@ -53,7 +53,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
   free ensures (memory_load8_le(mem, 1952bv64) == 1bv8);
@@ -110,7 +110,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) && (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)))));
 {
   call rely();
@@ -123,13 +123,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)) && (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_lock_security_write/clang/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/clang/basic_lock_security_write.expected
@@ -43,7 +43,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
   free ensures (memory_load8_le(mem, 1884bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
 {
   call rely();
@@ -97,7 +97,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_security_write/clang_O2/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/clang_O2/basic_lock_security_write.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_security_write/clang_no_plt_no_pic/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/clang_no_plt_no_pic/basic_lock_security_write.expected
@@ -43,7 +43,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
   free ensures (memory_load8_le(mem, 1884bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
 {
   call rely();
@@ -97,7 +97,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_security_write/clang_pic/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/clang_pic/basic_lock_security_write.expected
@@ -51,7 +51,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
   free ensures (memory_load8_le(mem, 1956bv64) == 1bv8);
@@ -108,7 +108,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
 {
   call rely();
@@ -121,7 +121,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_security_write/gcc/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/gcc/basic_lock_security_write.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
   free ensures (memory_load8_le(mem, 1908bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
 {
   call rely();
@@ -93,7 +93,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_security_write/gcc_O2/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/gcc_O2/basic_lock_security_write.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_security_write/gcc_no_plt_no_pic/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/gcc_no_plt_no_pic/basic_lock_security_write.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
   free ensures (memory_load8_le(mem, 1908bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
 {
   call rely();
@@ -93,7 +93,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_security_write/gcc_pic/basic_lock_security_write.expected
+++ b/src/test/correct/basic_lock_security_write/gcc_pic/basic_lock_security_write.expected
@@ -47,7 +47,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
   free ensures (memory_load8_le(mem, 1972bv64) == 1bv8);
@@ -104,7 +104,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr))) && (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))));
 {
   call rely();
@@ -117,7 +117,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_unlock/clang/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/clang/basic_lock_unlock.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_unlock/clang_O2/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/clang_O2/basic_lock_unlock.expected
@@ -34,7 +34,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -75,7 +75,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -88,7 +88,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_unlock/clang_no_plt_no_pic/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/clang_no_plt_no_pic/basic_lock_unlock.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_unlock/clang_pic/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/clang_pic/basic_lock_unlock.expected
@@ -40,7 +40,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -97,7 +97,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -110,7 +110,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_unlock/gcc/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/gcc/basic_lock_unlock.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_unlock/gcc_O2/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/gcc_O2/basic_lock_unlock.expected
@@ -34,7 +34,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -75,7 +75,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -88,7 +88,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_unlock/gcc_no_plt_no_pic/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/gcc_no_plt_no_pic/basic_lock_unlock.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_lock_unlock/gcc_pic/basic_lock_unlock.expected
+++ b/src/test/correct/basic_lock_unlock/gcc_pic/basic_lock_unlock.expected
@@ -38,7 +38,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -95,7 +95,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -108,7 +108,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) == 0bv32) ==> ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr))));
 }

--- a/src/test/correct/basic_loop_assign/clang/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/clang/basic_loop_assign.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
 }

--- a/src/test/correct/basic_loop_assign/clang_O2/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/clang_O2/basic_loop_assign.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
 }

--- a/src/test/correct/basic_loop_assign/clang_no_plt_no_pic/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/clang_no_plt_no_pic/basic_loop_assign.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
 }

--- a/src/test/correct/basic_loop_assign/clang_pic/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/clang_pic/basic_loop_assign.expected
@@ -40,7 +40,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -89,7 +89,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
 {
   call rely();
@@ -102,7 +102,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
 }

--- a/src/test/correct/basic_loop_assign/gcc/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/gcc/basic_loop_assign.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
 }

--- a/src/test/correct/basic_loop_assign/gcc_O2/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/gcc_O2/basic_loop_assign.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
 }

--- a/src/test/correct/basic_loop_assign/gcc_no_plt_no_pic/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/gcc_no_plt_no_pic/basic_loop_assign.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
 }

--- a/src/test/correct/basic_loop_assign/gcc_pic/basic_loop_assign.expected
+++ b/src/test/correct/basic_loop_assign/gcc_pic/basic_loop_assign.expected
@@ -38,7 +38,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -87,7 +87,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (((memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr))) || (bvsle32(memory_load32_le(mem, $x_addr), 10bv32) && bvslt32(old(memory_load32_le(mem, $x_addr)), 10bv32))) || ((memory_load32_le(mem, $x_addr) == 21bv32) && (old(memory_load32_le(mem, $x_addr)) == 20bv32)));
 {
   call rely();
@@ -100,7 +100,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) || ((memory_load32_le(mem, $x_addr) == 20bv32) && (memory_load32_le(mem, $x_addr) == 0bv32))) || ((memory_load32_le(mem, $x_addr) == 20bv32) && bvsle32(memory_load32_le(mem, $x_addr), 10bv32)));
 }

--- a/src/test/correct/basic_operation_evaluation/clang/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang/basic_operation_evaluation.expected
@@ -59,7 +59,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1952bv64) == 1bv8);
@@ -100,7 +100,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -111,7 +111,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R10, R31, R8, R9, stack;

--- a/src/test/correct/basic_operation_evaluation/clang/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang/basic_operation_evaluation.expected
@@ -114,7 +114,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;
+  modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R10, R31, R8, R9, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_operation_evaluation/clang_O2/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang_O2/basic_operation_evaluation.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1840bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/basic_operation_evaluation/clang_O2/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang_O2/basic_operation_evaluation.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_operation_evaluation/clang_no_plt_no_pic/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang_no_plt_no_pic/basic_operation_evaluation.expected
@@ -59,7 +59,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1952bv64) == 1bv8);
@@ -100,7 +100,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -111,7 +111,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R10, R31, R8, R9, stack;

--- a/src/test/correct/basic_operation_evaluation/clang_no_plt_no_pic/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang_no_plt_no_pic/basic_operation_evaluation.expected
@@ -114,7 +114,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;
+  modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R10, R31, R8, R9, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_operation_evaluation/clang_pic/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang_pic/basic_operation_evaluation.expected
@@ -59,7 +59,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1952bv64) == 1bv8);
@@ -100,7 +100,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -111,7 +111,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R10, R31, R8, R9, stack;

--- a/src/test/correct/basic_operation_evaluation/clang_pic/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/clang_pic/basic_operation_evaluation.expected
@@ -114,7 +114,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;
+  modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R10, R31, R8, R9, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_operation_evaluation/gcc/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc/basic_operation_evaluation.expected
@@ -106,7 +106,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R2, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_stack, R0, R1, R2, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_operation_evaluation/gcc/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc/basic_operation_evaluation.expected
@@ -51,7 +51,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1948bv64) == 1bv8);
@@ -92,7 +92,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -103,7 +103,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_stack, R0, R1, R2, R31, stack;

--- a/src/test/correct/basic_operation_evaluation/gcc_O2/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc_O2/basic_operation_evaluation.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/basic_operation_evaluation/gcc_O2/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc_O2/basic_operation_evaluation.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_operation_evaluation/gcc_no_plt_no_pic/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc_no_plt_no_pic/basic_operation_evaluation.expected
@@ -106,7 +106,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R2, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_stack, R0, R1, R2, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_operation_evaluation/gcc_no_plt_no_pic/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc_no_plt_no_pic/basic_operation_evaluation.expected
@@ -51,7 +51,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1948bv64) == 1bv8);
@@ -92,7 +92,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -103,7 +103,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_stack, R0, R1, R2, R31, stack;

--- a/src/test/correct/basic_operation_evaluation/gcc_pic/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc_pic/basic_operation_evaluation.expected
@@ -106,7 +106,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R2, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_stack, R0, R1, R2, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_operation_evaluation/gcc_pic/basic_operation_evaluation.expected
+++ b/src/test/correct/basic_operation_evaluation/gcc_pic/basic_operation_evaluation.expected
@@ -51,7 +51,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1948bv64) == 1bv8);
@@ -92,7 +92,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -103,7 +103,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R31, Gamma_stack, R0, R1, R2, R31, stack;

--- a/src/test/correct/basic_sec_policy_read/clang/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang/basic_sec_policy_read.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/clang/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang/basic_sec_policy_read.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 {
   call rely();
@@ -101,13 +101,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/clang_O2/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_O2/basic_sec_policy_read.expected
@@ -37,7 +37,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 {
   call rely();
@@ -91,13 +91,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, Gamma_R9, R0, R8, R9, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/clang_O2/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_O2/basic_sec_policy_read.expected
@@ -97,7 +97,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;
+  modifies Gamma_R0, Gamma_R8, Gamma_R9, R0, R8, R9, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/clang_no_plt_no_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_no_plt_no_pic/basic_sec_policy_read.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/clang_no_plt_no_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_no_plt_no_pic/basic_sec_policy_read.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 {
   call rely();
@@ -101,13 +101,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/clang_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_pic/basic_sec_policy_read.expected
@@ -55,7 +55,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
   free ensures (memory_load8_le(mem, 1968bv64) == 1bv8);
@@ -112,7 +112,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 {
   call rely();
@@ -125,13 +125,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/clang_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/clang_pic/basic_sec_policy_read.expected
@@ -131,7 +131,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/gcc/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc/basic_sec_policy_read.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
   free ensures (memory_load8_le(mem, 1888bv64) == 1bv8);
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 {
   call rely();
@@ -99,13 +99,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/gcc/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc/basic_sec_policy_read.expected
@@ -105,7 +105,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/gcc_O2/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_O2/basic_sec_policy_read.expected
@@ -31,7 +31,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -72,7 +72,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 {
   call rely();
@@ -85,13 +85,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R2, R0, R1, R2, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/gcc_O2/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_O2/basic_sec_policy_read.expected
@@ -91,7 +91,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;
+  modifies Gamma_R0, Gamma_R1, Gamma_R2, R0, R1, R2, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/gcc_no_plt_no_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_no_plt_no_pic/basic_sec_policy_read.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
   free ensures (memory_load8_le(mem, 1888bv64) == 1bv8);
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 {
   call rely();
@@ -99,13 +99,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/gcc_no_plt_no_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_no_plt_no_pic/basic_sec_policy_read.expected
@@ -105,7 +105,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/gcc_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_pic/basic_sec_policy_read.expected
@@ -129,7 +129,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_read/gcc_pic/basic_sec_policy_read.expected
+++ b/src/test/correct/basic_sec_policy_read/gcc_pic/basic_sec_policy_read.expected
@@ -53,7 +53,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
   free ensures (memory_load8_le(mem, 1952bv64) == 1bv8);
@@ -110,7 +110,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $z_addr)) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 {
   call rely();
@@ -123,13 +123,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basic_sec_policy_write/clang/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/clang/basic_sec_policy_write.expected
@@ -43,7 +43,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
   free ensures (memory_load8_le(mem, 1888bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
 {
   call rely();
@@ -97,7 +97,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 }

--- a/src/test/correct/basic_sec_policy_write/clang_O2/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/clang_O2/basic_sec_policy_write.expected
@@ -38,7 +38,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
   free ensures (memory_load8_le(mem, 1860bv64) == 1bv8);
@@ -79,7 +79,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
 {
   call rely();
@@ -92,7 +92,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 }

--- a/src/test/correct/basic_sec_policy_write/clang_no_plt_no_pic/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/clang_no_plt_no_pic/basic_sec_policy_write.expected
@@ -43,7 +43,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
   free ensures (memory_load8_le(mem, 1888bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
 {
   call rely();
@@ -97,7 +97,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 }

--- a/src/test/correct/basic_sec_policy_write/clang_pic/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/clang_pic/basic_sec_policy_write.expected
@@ -51,7 +51,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
   free ensures (memory_load8_le(mem, 1960bv64) == 1bv8);
@@ -108,7 +108,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
 {
   call rely();
@@ -121,7 +121,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 }

--- a/src/test/correct/basic_sec_policy_write/gcc/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/gcc/basic_sec_policy_write.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
 {
   call rely();
@@ -93,7 +93,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 }

--- a/src/test/correct/basic_sec_policy_write/gcc_O2/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/gcc_O2/basic_sec_policy_write.expected
@@ -38,7 +38,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -79,7 +79,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
 {
   call rely();
@@ -92,7 +92,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 }

--- a/src/test/correct/basic_sec_policy_write/gcc_no_plt_no_pic/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/gcc_no_plt_no_pic/basic_sec_policy_write.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
 {
   call rely();
@@ -93,7 +93,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 }

--- a/src/test/correct/basic_sec_policy_write/gcc_pic/basic_sec_policy_write.expected
+++ b/src/test/correct/basic_sec_policy_write/gcc_pic/basic_sec_policy_write.expected
@@ -47,7 +47,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
   free ensures (memory_load8_le(mem, 1976bv64) == 1bv8);
@@ -104,7 +104,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr));
 {
   call rely();
@@ -117,7 +117,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $z_addr) != 0bv32) ==> (memory_load32_le(mem, $z_addr) != 0bv32));
 }

--- a/src/test/correct/basicassign_gamma0/clang/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/clang/basicassign_gamma0.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/correct/basicassign_gamma0/clang_O2/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/clang_O2/basicassign_gamma0.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/correct/basicassign_gamma0/clang_no_plt_no_pic/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/clang_no_plt_no_pic/basicassign_gamma0.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/correct/basicassign_gamma0/clang_pic/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/clang_pic/basicassign_gamma0.expected
@@ -45,7 +45,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
   free ensures (memory_load8_le(mem, 1928bv64) == 1bv8);
@@ -102,7 +102,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
 {
   call rely();
@@ -115,7 +115,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/correct/basicassign_gamma0/gcc/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/gcc/basicassign_gamma0.expected
@@ -35,7 +35,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
   free ensures (memory_load8_le(mem, 1864bv64) == 1bv8);
@@ -76,7 +76,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
 {
   call rely();
@@ -89,7 +89,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/basicassign_gamma0/gcc_O2/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/gcc_O2/basicassign_gamma0.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;

--- a/src/test/correct/basicassign_gamma0/gcc_no_plt_no_pic/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/gcc_no_plt_no_pic/basicassign_gamma0.expected
@@ -35,7 +35,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
   free ensures (memory_load8_le(mem, 1864bv64) == 1bv8);
@@ -76,7 +76,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
 {
   call rely();
@@ -89,7 +89,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/basicassign_gamma0/gcc_pic/basicassign_gamma0.expected
+++ b/src/test/correct/basicassign_gamma0/gcc_pic/basicassign_gamma0.expected
@@ -43,7 +43,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
   free ensures (memory_load8_le(mem, 1928bv64) == 1bv8);
@@ -100,7 +100,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $secret_addr) == old(memory_load32_le(mem, $secret_addr)));
 {
   call rely();
@@ -113,7 +113,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/basicfree/clang/basicfree.expected
+++ b/src/test/correct/basicfree/clang/basicfree.expected
@@ -54,7 +54,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2080bv64) == 1bv8);
@@ -95,7 +95,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69695bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -106,7 +106,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/basicfree/clang/basicfree.expected
+++ b/src/test/correct/basicfree/clang/basicfree.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2080bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2081bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2082bv64) == 2bv8);
@@ -312,7 +312,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2080bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2081bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2082bv64) == 2bv8);

--- a/src/test/correct/basicfree/clang_O2/basicfree.expected
+++ b/src/test/correct/basicfree/clang_O2/basicfree.expected
@@ -7,7 +7,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1836bv64) == 1bv8);
@@ -48,7 +48,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -59,7 +59,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);

--- a/src/test/correct/basicfree/clang_O2/basicfree.expected
+++ b/src/test/correct/basicfree/clang_O2/basicfree.expected
@@ -62,7 +62,6 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_mem, mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/basicfree/clang_no_plt_no_pic/basicfree.expected
+++ b/src/test/correct/basicfree/clang_no_plt_no_pic/basicfree.expected
@@ -54,7 +54,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2080bv64) == 1bv8);
@@ -95,7 +95,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69695bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -106,7 +106,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/basicfree/clang_no_plt_no_pic/basicfree.expected
+++ b/src/test/correct/basicfree/clang_no_plt_no_pic/basicfree.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2080bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2081bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2082bv64) == 2bv8);
@@ -312,7 +312,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2080bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2081bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2082bv64) == 2bv8);

--- a/src/test/correct/basicfree/clang_pic/basicfree.expected
+++ b/src/test/correct/basicfree/clang_pic/basicfree.expected
@@ -54,7 +54,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2080bv64) == 1bv8);
@@ -95,7 +95,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69695bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -106,7 +106,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/basicfree/clang_pic/basicfree.expected
+++ b/src/test/correct/basicfree/clang_pic/basicfree.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2080bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2081bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2082bv64) == 2bv8);
@@ -312,7 +312,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2080bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2081bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2082bv64) == 2bv8);

--- a/src/test/correct/basicfree/gcc/basicfree.expected
+++ b/src/test/correct/basicfree/gcc/basicfree.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2076bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2077bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2078bv64) == 2bv8);
@@ -307,7 +307,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2076bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2077bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2078bv64) == 2bv8);

--- a/src/test/correct/basicfree/gcc/basicfree.expected
+++ b/src/test/correct/basicfree/gcc/basicfree.expected
@@ -52,7 +52,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2076bv64) == 1bv8);
@@ -93,7 +93,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -104,7 +104,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/basicfree/gcc_O2/basicfree.expected
+++ b/src/test/correct/basicfree/gcc_O2/basicfree.expected
@@ -7,7 +7,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -48,7 +48,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -59,7 +59,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);

--- a/src/test/correct/basicfree/gcc_O2/basicfree.expected
+++ b/src/test/correct/basicfree/gcc_O2/basicfree.expected
@@ -62,7 +62,6 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_mem, mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/basicfree/gcc_no_plt_no_pic/basicfree.expected
+++ b/src/test/correct/basicfree/gcc_no_plt_no_pic/basicfree.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2076bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2077bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2078bv64) == 2bv8);
@@ -307,7 +307,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2076bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2077bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2078bv64) == 2bv8);

--- a/src/test/correct/basicfree/gcc_no_plt_no_pic/basicfree.expected
+++ b/src/test/correct/basicfree/gcc_no_plt_no_pic/basicfree.expected
@@ -52,7 +52,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2076bv64) == 1bv8);
@@ -93,7 +93,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -104,7 +104,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/basicfree/gcc_pic/basicfree.expected
+++ b/src/test/correct/basicfree/gcc_pic/basicfree.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2076bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2077bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2078bv64) == 2bv8);
@@ -307,7 +307,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2076bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2077bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2078bv64) == 2bv8);

--- a/src/test/correct/basicfree/gcc_pic/basicfree.expected
+++ b/src/test/correct/basicfree/gcc_pic/basicfree.expected
@@ -52,7 +52,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2076bv64) == 1bv8);
@@ -93,7 +93,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -104,7 +104,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/cjump/clang/cjump.expected
+++ b/src/test/correct/cjump/clang/cjump.expected
@@ -49,7 +49,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -90,7 +90,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -101,7 +101,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/correct/cjump/clang_O2/cjump.expected
+++ b/src/test/correct/cjump/clang_O2/cjump.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1864bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -88,7 +88,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R11, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R11, R8, R9, mem;

--- a/src/test/correct/cjump/clang_no_plt_no_pic/cjump.expected
+++ b/src/test/correct/cjump/clang_no_plt_no_pic/cjump.expected
@@ -49,7 +49,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -90,7 +90,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -101,7 +101,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/correct/cjump/clang_pic/cjump.expected
+++ b/src/test/correct/cjump/clang_pic/cjump.expected
@@ -57,7 +57,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1992bv64) == 1bv8);
@@ -114,7 +114,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -125,7 +125,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/correct/cjump/gcc/cjump.expected
+++ b/src/test/correct/cjump/gcc/cjump.expected
@@ -43,7 +43,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -95,7 +95,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/cjump/gcc_O2/cjump.expected
+++ b/src/test/correct/cjump/gcc_O2/cjump.expected
@@ -34,7 +34,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -75,7 +75,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -86,7 +86,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R3, Gamma_mem, R0, R1, R2, R3, mem;

--- a/src/test/correct/cjump/gcc_no_plt_no_pic/cjump.expected
+++ b/src/test/correct/cjump/gcc_no_plt_no_pic/cjump.expected
@@ -43,7 +43,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -95,7 +95,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/cjump/gcc_pic/cjump.expected
+++ b/src/test/correct/cjump/gcc_pic/cjump.expected
@@ -51,7 +51,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1976bv64) == 1bv8);
@@ -108,7 +108,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -119,7 +119,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/function/clang/function.expected
+++ b/src/test/correct/function/clang/function.expected
@@ -111,7 +111,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1884bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1885bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1886bv64) == 2bv8);

--- a/src/test/correct/function/clang/function.expected
+++ b/src/test/correct/function/clang/function.expected
@@ -56,7 +56,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1884bv64) == 1bv8);
@@ -97,7 +97,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -108,7 +108,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, R0;

--- a/src/test/correct/function/clang_O2/function.expected
+++ b/src/test/correct/function/clang_O2/function.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1872bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -88,7 +88,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R11, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R11, R8, R9, mem;

--- a/src/test/correct/function/clang_no_plt_no_pic/function.expected
+++ b/src/test/correct/function/clang_no_plt_no_pic/function.expected
@@ -111,7 +111,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1884bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1885bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1886bv64) == 2bv8);

--- a/src/test/correct/function/clang_no_plt_no_pic/function.expected
+++ b/src/test/correct/function/clang_no_plt_no_pic/function.expected
@@ -56,7 +56,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1884bv64) == 1bv8);
@@ -97,7 +97,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -108,7 +108,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, R0;

--- a/src/test/correct/function/clang_pic/function.expected
+++ b/src/test/correct/function/clang_pic/function.expected
@@ -127,7 +127,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1956bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1957bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1958bv64) == 2bv8);

--- a/src/test/correct/function/clang_pic/function.expected
+++ b/src/test/correct/function/clang_pic/function.expected
@@ -56,7 +56,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1956bv64) == 1bv8);
@@ -113,7 +113,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -124,7 +124,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, R0;

--- a/src/test/correct/function/gcc/function.expected
+++ b/src/test/correct/function/gcc/function.expected
@@ -110,7 +110,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1896bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1897bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1898bv64) == 2bv8);

--- a/src/test/correct/function/gcc/function.expected
+++ b/src/test/correct/function/gcc/function.expected
@@ -55,7 +55,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -96,7 +96,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -107,7 +107,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, R0;

--- a/src/test/correct/function/gcc_O2/function.expected
+++ b/src/test/correct/function/gcc_O2/function.expected
@@ -34,7 +34,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -75,7 +75,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -86,7 +86,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R3, Gamma_mem, R0, R1, R2, R3, mem;

--- a/src/test/correct/function/gcc_no_plt_no_pic/function.expected
+++ b/src/test/correct/function/gcc_no_plt_no_pic/function.expected
@@ -110,7 +110,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1896bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1897bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1898bv64) == 2bv8);

--- a/src/test/correct/function/gcc_no_plt_no_pic/function.expected
+++ b/src/test/correct/function/gcc_no_plt_no_pic/function.expected
@@ -55,7 +55,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -96,7 +96,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -107,7 +107,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, R0;

--- a/src/test/correct/function/gcc_pic/function.expected
+++ b/src/test/correct/function/gcc_pic/function.expected
@@ -55,7 +55,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1960bv64) == 1bv8);
@@ -112,7 +112,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -123,7 +123,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, R0;

--- a/src/test/correct/function/gcc_pic/function.expected
+++ b/src/test/correct/function/gcc_pic/function.expected
@@ -126,7 +126,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 1960bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1961bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1962bv64) == 2bv8);

--- a/src/test/correct/function1/clang/function1.expected
+++ b/src/test/correct/function1/clang/function1.expected
@@ -145,7 +145,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R31, R8, R9, stack;
   free requires (memory_load8_le(mem, 2024bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2025bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2026bv64) == 2bv8);
@@ -389,7 +389,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2024bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2025bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2026bv64) == 2bv8);

--- a/src/test/correct/function1/clang/function1.expected
+++ b/src/test/correct/function1/clang/function1.expected
@@ -86,7 +86,7 @@ function {:bvbuiltin "sign_extend 32"} sign_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2024bv64) == 1bv8);
@@ -131,7 +131,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -142,7 +142,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R31, R8, R9, stack;

--- a/src/test/correct/function1/clang_O2/function1.expected
+++ b/src/test/correct/function1/clang_O2/function1.expected
@@ -261,7 +261,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1976bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1977bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1978bv64) == 2bv8);

--- a/src/test/correct/function1/clang_O2/function1.expected
+++ b/src/test/correct/function1/clang_O2/function1.expected
@@ -65,7 +65,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1976bv64) == 1bv8);
@@ -110,7 +110,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -121,7 +121,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R10, Gamma_R11, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R1, R10, R11, R16, R17, R29, R30, R31, R8, R9, mem, stack;

--- a/src/test/correct/function1/clang_no_plt_no_pic/function1.expected
+++ b/src/test/correct/function1/clang_no_plt_no_pic/function1.expected
@@ -145,7 +145,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R31, R8, R9, stack;
   free requires (memory_load8_le(mem, 2024bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2025bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2026bv64) == 2bv8);
@@ -389,7 +389,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2024bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2025bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2026bv64) == 2bv8);

--- a/src/test/correct/function1/clang_no_plt_no_pic/function1.expected
+++ b/src/test/correct/function1/clang_no_plt_no_pic/function1.expected
@@ -86,7 +86,7 @@ function {:bvbuiltin "sign_extend 32"} sign_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2024bv64) == 1bv8);
@@ -131,7 +131,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -142,7 +142,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R31, R8, R9, stack;

--- a/src/test/correct/function1/clang_pic/function1.expected
+++ b/src/test/correct/function1/clang_pic/function1.expected
@@ -86,7 +86,7 @@ function {:bvbuiltin "sign_extend 32"} sign_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2096bv64) == 1bv8);
@@ -147,7 +147,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69591bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -158,7 +158,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R31, R8, R9, stack;

--- a/src/test/correct/function1/clang_pic/function1.expected
+++ b/src/test/correct/function1/clang_pic/function1.expected
@@ -161,7 +161,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_stack, R0, R31, R8, R9, stack;
   free requires (memory_load8_le(mem, 2096bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2097bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2098bv64) == 2bv8);
@@ -473,7 +473,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2096bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2097bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2098bv64) == 2bv8);

--- a/src/test/correct/function1/gcc/function1.expected
+++ b/src/test/correct/function1/gcc/function1.expected
@@ -81,7 +81,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2048bv64) == 1bv8);
@@ -130,7 +130,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -141,7 +141,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_stack, R0, R1, R31, stack;

--- a/src/test/correct/function1/gcc/function1.expected
+++ b/src/test/correct/function1/gcc/function1.expected
@@ -144,7 +144,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_stack, R0, R1, R31, stack;
   free requires (memory_load8_le(mem, 2048bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2049bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2050bv64) == 2bv8);
@@ -410,7 +410,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2048bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2049bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2050bv64) == 2bv8);

--- a/src/test/correct/function1/gcc_O2/function1.expected
+++ b/src/test/correct/function1/gcc_O2/function1.expected
@@ -61,7 +61,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2048bv64) == 1bv8);
@@ -110,7 +110,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -121,7 +121,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure __printf_chk();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/function1/gcc_O2/function1.expected
+++ b/src/test/correct/function1/gcc_O2/function1.expected
@@ -124,7 +124,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure __printf_chk();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2048bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2049bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2050bv64) == 2bv8);

--- a/src/test/correct/function1/gcc_no_plt_no_pic/function1.expected
+++ b/src/test/correct/function1/gcc_no_plt_no_pic/function1.expected
@@ -81,7 +81,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2048bv64) == 1bv8);
@@ -130,7 +130,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -141,7 +141,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_stack, R0, R1, R31, stack;

--- a/src/test/correct/function1/gcc_no_plt_no_pic/function1.expected
+++ b/src/test/correct/function1/gcc_no_plt_no_pic/function1.expected
@@ -144,7 +144,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_stack, R0, R1, R31, stack;
   free requires (memory_load8_le(mem, 2048bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2049bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2050bv64) == 2bv8);
@@ -410,7 +410,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2048bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2049bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2050bv64) == 2bv8);

--- a/src/test/correct/function1/gcc_pic/function1.expected
+++ b/src/test/correct/function1/gcc_pic/function1.expected
@@ -160,7 +160,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure get_two()
-  modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_stack, R0, R1, R31, stack;
   free requires (memory_load8_le(mem, 2112bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2113bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2114bv64) == 2bv8);
@@ -493,7 +493,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2112bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2113bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2114bv64) == 2bv8);

--- a/src/test/correct/function1/gcc_pic/function1.expected
+++ b/src/test/correct/function1/gcc_pic/function1.expected
@@ -81,7 +81,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2112bv64) == 1bv8);
@@ -146,7 +146,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 68999bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -157,7 +157,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure get_two()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_stack, R0, R1, R31, stack;

--- a/src/test/correct/functions_with_params/clang/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang/functions_with_params.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R29, R30, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
@@ -232,7 +232,7 @@ procedure main()
 }
 
 procedure plus_one()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 1912bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1913bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1914bv64) == 2bv8);

--- a/src/test/correct/functions_with_params/clang/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang/functions_with_params.expected
@@ -54,7 +54,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -95,7 +95,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -106,7 +106,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;

--- a/src/test/correct/functions_with_params/clang_O2/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang_O2/functions_with_params.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1848bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/functions_with_params/clang_O2/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang_O2/functions_with_params.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/functions_with_params/clang_no_plt_no_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang_no_plt_no_pic/functions_with_params.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R29, R30, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
@@ -232,7 +232,7 @@ procedure main()
 }
 
 procedure plus_one()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 1912bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1913bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1914bv64) == 2bv8);

--- a/src/test/correct/functions_with_params/clang_no_plt_no_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang_no_plt_no_pic/functions_with_params.expected
@@ -54,7 +54,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -95,7 +95,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -106,7 +106,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;

--- a/src/test/correct/functions_with_params/clang_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang_pic/functions_with_params.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R29, R30, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);
@@ -232,7 +232,7 @@ procedure main()
 }
 
 procedure plus_one()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 1912bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1913bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1914bv64) == 2bv8);

--- a/src/test/correct/functions_with_params/clang_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/clang_pic/functions_with_params.expected
@@ -54,7 +54,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -95,7 +95,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -106,7 +106,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_R8, Gamma_stack, R0, R29, R30, R31, R8, stack;

--- a/src/test/correct/functions_with_params/gcc/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc/functions_with_params.expected
@@ -52,7 +52,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1904bv64) == 1bv8);
@@ -93,7 +93,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -104,7 +104,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;

--- a/src/test/correct/functions_with_params/gcc/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc/functions_with_params.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
@@ -227,7 +227,7 @@ procedure main()
 }
 
 procedure plus_one()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 1904bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1905bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1906bv64) == 2bv8);

--- a/src/test/correct/functions_with_params/gcc_O2/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc_O2/functions_with_params.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/functions_with_params/gcc_O2/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc_O2/functions_with_params.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/functions_with_params/gcc_no_plt_no_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc_no_plt_no_pic/functions_with_params.expected
@@ -52,7 +52,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1904bv64) == 1bv8);
@@ -93,7 +93,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -104,7 +104,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;

--- a/src/test/correct/functions_with_params/gcc_no_plt_no_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc_no_plt_no_pic/functions_with_params.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
@@ -227,7 +227,7 @@ procedure main()
 }
 
 procedure plus_one()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 1904bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1905bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1906bv64) == 2bv8);

--- a/src/test/correct/functions_with_params/gcc_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc_pic/functions_with_params.expected
@@ -52,7 +52,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1904bv64) == 1bv8);
@@ -93,7 +93,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -104,7 +104,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;

--- a/src/test/correct/functions_with_params/gcc_pic/functions_with_params.expected
+++ b/src/test/correct/functions_with_params/gcc_pic/functions_with_params.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
@@ -227,7 +227,7 @@ procedure main()
 }
 
 procedure plus_one()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 1904bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1905bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1906bv64) == 2bv8);

--- a/src/test/correct/ifbranches/clang/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang/ifbranches.expected
@@ -49,7 +49,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -90,7 +90,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -101,7 +101,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/ifbranches/clang/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang/ifbranches.expected
@@ -104,7 +104,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/ifbranches/clang_O2/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang_O2/ifbranches.expected
@@ -18,7 +18,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1848bv64) == 1bv8);
@@ -59,7 +59,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -70,7 +70,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, R0, R8;

--- a/src/test/correct/ifbranches/clang_O2/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang_O2/ifbranches.expected
@@ -73,7 +73,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, Gamma_mem, R0, R8, mem;
+  modifies Gamma_R0, Gamma_R8, R0, R8;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/ifbranches/clang_no_plt_no_pic/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang_no_plt_no_pic/ifbranches.expected
@@ -49,7 +49,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -90,7 +90,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -101,7 +101,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/ifbranches/clang_no_plt_no_pic/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang_no_plt_no_pic/ifbranches.expected
@@ -104,7 +104,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/ifbranches/clang_pic/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang_pic/ifbranches.expected
@@ -49,7 +49,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -90,7 +90,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -101,7 +101,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/ifbranches/clang_pic/ifbranches.expected
+++ b/src/test/correct/ifbranches/clang_pic/ifbranches.expected
@@ -104,7 +104,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/ifbranches/gcc/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc/ifbranches.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1904bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -99,7 +99,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/ifbranches/gcc/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc/ifbranches.expected
@@ -102,7 +102,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/ifbranches/gcc_O2/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc_O2/ifbranches.expected
@@ -71,7 +71,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/ifbranches/gcc_O2/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc_O2/ifbranches.expected
@@ -16,7 +16,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -57,7 +57,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -68,7 +68,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/ifbranches/gcc_no_plt_no_pic/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc_no_plt_no_pic/ifbranches.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1904bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -99,7 +99,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/ifbranches/gcc_no_plt_no_pic/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc_no_plt_no_pic/ifbranches.expected
@@ -102,7 +102,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/ifbranches/gcc_pic/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc_pic/ifbranches.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1904bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -99,7 +99,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/ifbranches/gcc_pic/ifbranches.expected
+++ b/src/test/correct/ifbranches/gcc_pic/ifbranches.expected
@@ -102,7 +102,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/ifglobal/clang/ifglobal.expected
+++ b/src/test/correct/ifglobal/clang/ifglobal.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -99,7 +99,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/correct/ifglobal/clang_O2/ifglobal.expected
+++ b/src/test/correct/ifglobal/clang_O2/ifglobal.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -88,7 +88,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/correct/ifglobal/clang_no_plt_no_pic/ifglobal.expected
+++ b/src/test/correct/ifglobal/clang_no_plt_no_pic/ifglobal.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -99,7 +99,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/correct/ifglobal/clang_pic/ifglobal.expected
+++ b/src/test/correct/ifglobal/clang_pic/ifglobal.expected
@@ -55,7 +55,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -104,7 +104,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -115,7 +115,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/correct/ifglobal/gcc/ifglobal.expected
+++ b/src/test/correct/ifglobal/gcc/ifglobal.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1876bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/ifglobal/gcc_O2/ifglobal.expected
+++ b/src/test/correct/ifglobal/gcc_O2/ifglobal.expected
@@ -35,7 +35,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -76,7 +76,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -87,7 +87,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/ifglobal/gcc_no_plt_no_pic/ifglobal.expected
+++ b/src/test/correct/ifglobal/gcc_no_plt_no_pic/ifglobal.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1876bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/ifglobal/gcc_pic/ifglobal.expected
+++ b/src/test/correct/ifglobal/gcc_pic/ifglobal.expected
@@ -49,7 +49,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1940bv64) == 1bv8);
@@ -98,7 +98,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -109,7 +109,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/indirect_call/clang_O2/indirect_call.expected
+++ b/src/test/correct/indirect_call/clang_O2/indirect_call.expected
@@ -135,7 +135,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69672bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69673bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69674bv64) == 0bv8);
@@ -341,7 +341,7 @@ procedure main()
 }
 
 procedure puts();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1952bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1953bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1954bv64) == 2bv8);

--- a/src/test/correct/indirect_call/clang_O2/indirect_call.expected
+++ b/src/test/correct/indirect_call/clang_O2/indirect_call.expected
@@ -38,7 +38,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1952bv64) == 1bv8);
@@ -121,7 +121,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -132,7 +132,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;

--- a/src/test/correct/indirect_call/gcc_O2/indirect_call.expected
+++ b/src/test/correct/indirect_call/gcc_O2/indirect_call.expected
@@ -141,7 +141,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure greet()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_mem, R0, R16, R17, mem;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, R0, R16, R17;
   free requires (memory_load8_le(mem, 1984bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1985bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1986bv64) == 2bv8);
@@ -320,7 +320,7 @@ procedure greet()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);
@@ -536,7 +536,7 @@ procedure main()
 }
 
 procedure puts();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1984bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1985bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1986bv64) == 2bv8);

--- a/src/test/correct/indirect_call/gcc_O2/indirect_call.expected
+++ b/src/test/correct/indirect_call/gcc_O2/indirect_call.expected
@@ -38,7 +38,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1984bv64) == 1bv8);
@@ -127,7 +127,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -138,7 +138,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure greet()
   modifies Gamma_R0, Gamma_R16, Gamma_R17, R0, R16, R17;

--- a/src/test/correct/initialisation/clang/initialisation.expected
+++ b/src/test/correct/initialisation/clang/initialisation.expected
@@ -81,7 +81,7 @@ function {:bvbuiltin "zero_extend 1"} zero_extend1_64(bv64) returns (bv65);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -122,7 +122,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -133,7 +133,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R11, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R11, R8, R9, mem;

--- a/src/test/correct/initialisation/clang_O2/initialisation.expected
+++ b/src/test/correct/initialisation/clang_O2/initialisation.expected
@@ -83,7 +83,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1908bv64) == 1bv8);
@@ -124,7 +124,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -135,7 +135,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R11, Gamma_R12, Gamma_R13, Gamma_R14, Gamma_R15, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R11, R12, R13, R14, R15, R8, R9, mem;

--- a/src/test/correct/initialisation/clang_no_plt_no_pic/initialisation.expected
+++ b/src/test/correct/initialisation/clang_no_plt_no_pic/initialisation.expected
@@ -81,7 +81,7 @@ function {:bvbuiltin "zero_extend 1"} zero_extend1_64(bv64) returns (bv65);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1912bv64) == 1bv8);
@@ -122,7 +122,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -133,7 +133,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R11, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R11, R8, R9, mem;

--- a/src/test/correct/initialisation/clang_pic/initialisation.expected
+++ b/src/test/correct/initialisation/clang_pic/initialisation.expected
@@ -79,7 +79,7 @@ function {:bvbuiltin "zero_extend 1"} zero_extend1_64(bv64) returns (bv65);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2048bv64) == 1bv8);
@@ -152,7 +152,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69567bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -163,7 +163,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R8, R9, mem;

--- a/src/test/correct/initialisation/gcc/initialisation.expected
+++ b/src/test/correct/initialisation/gcc/initialisation.expected
@@ -69,7 +69,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1956bv64) == 1bv8);
@@ -110,7 +110,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -121,7 +121,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/initialisation/gcc_O2/initialisation.expected
+++ b/src/test/correct/initialisation/gcc_O2/initialisation.expected
@@ -79,7 +79,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -120,7 +120,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -131,7 +131,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_R3, Gamma_R4, Gamma_R5, Gamma_R6, Gamma_mem, R0, R1, R2, R3, R4, R5, R6, mem;

--- a/src/test/correct/initialisation/gcc_no_plt_no_pic/initialisation.expected
+++ b/src/test/correct/initialisation/gcc_no_plt_no_pic/initialisation.expected
@@ -69,7 +69,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1956bv64) == 1bv8);
@@ -110,7 +110,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -121,7 +121,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/initialisation/gcc_pic/initialisation.expected
+++ b/src/test/correct/initialisation/gcc_pic/initialisation.expected
@@ -69,7 +69,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2084bv64) == 1bv8);
@@ -142,7 +142,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 68999bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -153,7 +153,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/jumptable/clang_O2/jumptable.expected
+++ b/src/test/correct/jumptable/clang_O2/jumptable.expected
@@ -38,7 +38,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -79,7 +79,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -90,7 +90,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/correct/jumptable/gcc_O2/jumptable.expected
+++ b/src/test/correct/jumptable/gcc_O2/jumptable.expected
@@ -60,7 +60,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1976bv64) == 1bv8);
@@ -101,7 +101,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -112,7 +112,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure add_six()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/jumptable3/gcc/jumptable3.expected
+++ b/src/test/correct/jumptable3/gcc/jumptable3.expected
@@ -64,7 +64,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2356bv64) == 1bv8);
@@ -105,7 +105,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -116,7 +116,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure add_six()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/jumptable3/gcc_O2/jumptable3.expected
+++ b/src/test/correct/jumptable3/gcc_O2/jumptable3.expected
@@ -40,7 +40,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2232bv64) == 1bv8);
@@ -81,7 +81,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -92,7 +92,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/jumptable3/gcc_no_plt_no_pic/jumptable3.expected
+++ b/src/test/correct/jumptable3/gcc_no_plt_no_pic/jumptable3.expected
@@ -64,7 +64,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2356bv64) == 1bv8);
@@ -105,7 +105,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -116,7 +116,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure add_six()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/jumptable3/gcc_pic/jumptable3.expected
+++ b/src/test/correct/jumptable3/gcc_pic/jumptable3.expected
@@ -64,7 +64,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2420bv64) == 1bv8);
@@ -113,7 +113,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -124,7 +124,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure add_six()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/correct/malloc_with_local/clang/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang/malloc_with_local.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2256bv64) == 1bv8);
@@ -179,7 +179,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -190,7 +190,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local/clang/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang/malloc_with_local.expected
@@ -193,7 +193,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);
@@ -683,7 +683,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);
@@ -878,7 +878,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local/clang_O2/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_O2/malloc_with_local.expected
@@ -40,7 +40,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -141,7 +141,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -152,7 +152,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, stack;

--- a/src/test/correct/malloc_with_local/clang_O2/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_O2/malloc_with_local.expected
@@ -155,7 +155,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69672bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69673bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69674bv64) == 0bv8);
@@ -406,7 +406,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1964bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1965bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1966bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local/clang_no_plt_no_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_no_plt_no_pic/malloc_with_local.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2256bv64) == 1bv8);
@@ -179,7 +179,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -190,7 +190,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local/clang_no_plt_no_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_no_plt_no_pic/malloc_with_local.expected
@@ -193,7 +193,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);
@@ -683,7 +683,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);
@@ -878,7 +878,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local/clang_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_pic/malloc_with_local.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2256bv64) == 1bv8);
@@ -179,7 +179,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -190,7 +190,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local/clang_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/clang_pic/malloc_with_local.expected
@@ -193,7 +193,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);
@@ -683,7 +683,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);
@@ -878,7 +878,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2256bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2257bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2258bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local/gcc/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc/malloc_with_local.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2248bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local/gcc/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc/malloc_with_local.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);
@@ -730,7 +730,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);
@@ -947,7 +947,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local/gcc_O2/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_O2/malloc_with_local.expected
@@ -42,7 +42,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2088bv64) == 1bv8);
@@ -154,7 +154,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -165,7 +165,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure __printf_chk();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local/gcc_O2/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_O2/malloc_with_local.expected
@@ -168,7 +168,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure __printf_chk();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2088bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2089bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2090bv64) == 2bv8);
@@ -385,7 +385,7 @@ procedure __printf_chk();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R2, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R16, R17, R2, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R2, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R2, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/malloc_with_local/gcc_no_plt_no_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_no_plt_no_pic/malloc_with_local.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2248bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local/gcc_no_plt_no_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_no_plt_no_pic/malloc_with_local.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);
@@ -730,7 +730,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);
@@ -947,7 +947,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local/gcc_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_pic/malloc_with_local.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2248bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local/gcc_pic/malloc_with_local.expected
+++ b/src/test/correct/malloc_with_local/gcc_pic/malloc_with_local.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);
@@ -730,7 +730,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);
@@ -947,7 +947,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2248bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2249bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2250bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local2/clang/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang/malloc_with_local2.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2292bv64) == 1bv8);
@@ -179,7 +179,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -190,7 +190,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local2/clang/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang/malloc_with_local2.expected
@@ -193,7 +193,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);
@@ -695,7 +695,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);
@@ -890,7 +890,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local2/clang_O2/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_O2/malloc_with_local2.expected
@@ -40,7 +40,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -141,7 +141,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -152,7 +152,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, stack;

--- a/src/test/correct/malloc_with_local2/clang_O2/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_O2/malloc_with_local2.expected
@@ -155,7 +155,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69672bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69673bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69674bv64) == 0bv8);
@@ -406,7 +406,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1964bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1965bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1966bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local2/clang_no_plt_no_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_no_plt_no_pic/malloc_with_local2.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2292bv64) == 1bv8);
@@ -179,7 +179,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -190,7 +190,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local2/clang_no_plt_no_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_no_plt_no_pic/malloc_with_local2.expected
@@ -193,7 +193,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);
@@ -695,7 +695,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);
@@ -890,7 +890,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local2/clang_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_pic/malloc_with_local2.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2292bv64) == 1bv8);
@@ -179,7 +179,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -190,7 +190,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local2/clang_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/clang_pic/malloc_with_local2.expected
@@ -193,7 +193,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);
@@ -695,7 +695,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);
@@ -890,7 +890,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2292bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2293bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2294bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local2/gcc/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc/malloc_with_local2.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);
@@ -740,7 +740,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);
@@ -957,7 +957,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local2/gcc/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc/malloc_with_local2.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2272bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local2/gcc_O2/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_O2/malloc_with_local2.expected
@@ -42,7 +42,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2088bv64) == 1bv8);
@@ -154,7 +154,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -165,7 +165,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure __printf_chk();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local2/gcc_O2/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_O2/malloc_with_local2.expected
@@ -168,7 +168,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure __printf_chk();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2088bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2089bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2090bv64) == 2bv8);
@@ -385,7 +385,7 @@ procedure __printf_chk();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R2, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R16, R17, R2, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R2, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R2, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/malloc_with_local2/gcc_no_plt_no_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_no_plt_no_pic/malloc_with_local2.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);
@@ -740,7 +740,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);
@@ -957,7 +957,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local2/gcc_no_plt_no_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_no_plt_no_pic/malloc_with_local2.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2272bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local2/gcc_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_pic/malloc_with_local2.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);
@@ -740,7 +740,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);
@@ -957,7 +957,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2272bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2273bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2274bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local2/gcc_pic/malloc_with_local2.expected
+++ b/src/test/correct/malloc_with_local2/gcc_pic/malloc_with_local2.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2272bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local3/clang/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang/malloc_with_local3.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);
@@ -722,7 +722,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);
@@ -1174,7 +1174,7 @@ procedure printCharValue()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local3/clang/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang/malloc_with_local3.expected
@@ -79,7 +79,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2344bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local3/clang_O2/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_O2/malloc_with_local3.expected
@@ -40,7 +40,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1996bv64) == 1bv8);
@@ -147,7 +147,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -158,7 +158,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, stack;

--- a/src/test/correct/malloc_with_local3/clang_O2/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_O2/malloc_with_local3.expected
@@ -161,7 +161,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69672bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69673bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69674bv64) == 0bv8);
@@ -424,7 +424,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1996bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1997bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1998bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local3/clang_no_plt_no_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_no_plt_no_pic/malloc_with_local3.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);
@@ -722,7 +722,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);
@@ -1174,7 +1174,7 @@ procedure printCharValue()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local3/clang_no_plt_no_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_no_plt_no_pic/malloc_with_local3.expected
@@ -79,7 +79,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2344bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local3/clang_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_pic/malloc_with_local3.expected
@@ -200,7 +200,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);
@@ -722,7 +722,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);
@@ -1174,7 +1174,7 @@ procedure printCharValue()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2344bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2345bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2346bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local3/clang_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/clang_pic/malloc_with_local3.expected
@@ -79,7 +79,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2344bv64) == 1bv8);
@@ -186,7 +186,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -197,7 +197,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local3/gcc/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc/malloc_with_local3.expected
@@ -75,7 +75,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2328bv64) == 1bv8);
@@ -191,7 +191,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -202,7 +202,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local3/gcc/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc/malloc_with_local3.expected
@@ -205,7 +205,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);
@@ -756,7 +756,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);
@@ -1244,7 +1244,7 @@ procedure printCharValue()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local3/gcc_O2/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_O2/malloc_with_local3.expected
@@ -191,7 +191,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure __printf_chk();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2264bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2265bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2266bv64) == 2bv8);
@@ -408,7 +408,7 @@ procedure __printf_chk();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2264bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2265bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2266bv64) == 2bv8);
@@ -916,7 +916,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2264bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2265bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2266bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local3/gcc_O2/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_O2/malloc_with_local3.expected
@@ -65,7 +65,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2264bv64) == 1bv8);
@@ -177,7 +177,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -188,7 +188,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure __printf_chk();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local3/gcc_no_plt_no_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_no_plt_no_pic/malloc_with_local3.expected
@@ -75,7 +75,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2328bv64) == 1bv8);
@@ -191,7 +191,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -202,7 +202,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local3/gcc_no_plt_no_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_no_plt_no_pic/malloc_with_local3.expected
@@ -205,7 +205,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);
@@ -756,7 +756,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);
@@ -1244,7 +1244,7 @@ procedure printCharValue()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);

--- a/src/test/correct/malloc_with_local3/gcc_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_pic/malloc_with_local3.expected
@@ -75,7 +75,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2328bv64) == 1bv8);
@@ -191,7 +191,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -202,7 +202,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/malloc_with_local3/gcc_pic/malloc_with_local3.expected
+++ b/src/test/correct/malloc_with_local3/gcc_pic/malloc_with_local3.expected
@@ -205,7 +205,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);
@@ -756,7 +756,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);
@@ -1244,7 +1244,7 @@ procedure printCharValue()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2328bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2329bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2330bv64) == 2bv8);

--- a/src/test/correct/multi_malloc/clang/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang/multi_malloc.expected
@@ -166,7 +166,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);
@@ -539,7 +539,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);
@@ -680,7 +680,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);

--- a/src/test/correct/multi_malloc/clang/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang/multi_malloc.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2232bv64) == 1bv8);
@@ -152,7 +152,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -163,7 +163,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/multi_malloc/clang_O2/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_O2/multi_malloc.expected
@@ -128,7 +128,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69672bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69673bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69674bv64) == 0bv8);
@@ -318,7 +318,7 @@ procedure main()
 }
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1948bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1949bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1950bv64) == 2bv8);

--- a/src/test/correct/multi_malloc/clang_O2/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_O2/multi_malloc.expected
@@ -40,7 +40,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1948bv64) == 1bv8);
@@ -114,7 +114,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -125,7 +125,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R29, R30, R31, stack;

--- a/src/test/correct/multi_malloc/clang_no_plt_no_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_no_plt_no_pic/multi_malloc.expected
@@ -166,7 +166,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);
@@ -539,7 +539,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);
@@ -680,7 +680,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);

--- a/src/test/correct/multi_malloc/clang_no_plt_no_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_no_plt_no_pic/multi_malloc.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2232bv64) == 1bv8);
@@ -152,7 +152,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -163,7 +163,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/multi_malloc/clang_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_pic/multi_malloc.expected
@@ -166,7 +166,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);
@@ -539,7 +539,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);
@@ -680,7 +680,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2232bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2233bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2234bv64) == 2bv8);

--- a/src/test/correct/multi_malloc/clang_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/clang_pic/multi_malloc.expected
@@ -78,7 +78,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2232bv64) == 1bv8);
@@ -152,7 +152,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69703bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -163,7 +163,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/multi_malloc/gcc/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc/multi_malloc.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2224bv64) == 1bv8);
@@ -159,7 +159,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -170,7 +170,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/multi_malloc/gcc/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc/multi_malloc.expected
@@ -173,7 +173,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);
@@ -586,7 +586,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);
@@ -749,7 +749,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);

--- a/src/test/correct/multi_malloc/gcc_O2/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_O2/multi_malloc.expected
@@ -42,7 +42,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2024bv64) == 1bv8);
@@ -127,7 +127,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -138,7 +138,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure __printf_chk();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/multi_malloc/gcc_O2/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_O2/multi_malloc.expected
@@ -141,7 +141,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure __printf_chk();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2024bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2025bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2026bv64) == 2bv8);
@@ -304,7 +304,7 @@ procedure __printf_chk();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R2, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R16, R17, R2, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R1, Gamma_R16, Gamma_R17, Gamma_R2, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R1, R16, R17, R2, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/multi_malloc/gcc_no_plt_no_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_no_plt_no_pic/multi_malloc.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2224bv64) == 1bv8);
@@ -159,7 +159,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -170,7 +170,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/multi_malloc/gcc_no_plt_no_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_no_plt_no_pic/multi_malloc.expected
@@ -173,7 +173,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);
@@ -586,7 +586,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);
@@ -749,7 +749,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);

--- a/src/test/correct/multi_malloc/gcc_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_pic/multi_malloc.expected
@@ -74,7 +74,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2224bv64) == 1bv8);
@@ -159,7 +159,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -170,7 +170,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure #free();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/multi_malloc/gcc_pic/multi_malloc.expected
+++ b/src/test/correct/multi_malloc/gcc_pic/multi_malloc.expected
@@ -173,7 +173,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure #free();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);
@@ -586,7 +586,7 @@ procedure main()
 }
 
 procedure malloc();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);
@@ -749,7 +749,7 @@ procedure malloc();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure printf();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 2224bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2225bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2226bv64) == 2bv8);

--- a/src/test/correct/nestedif/clang/nestedif.expected
+++ b/src/test/correct/nestedif/clang/nestedif.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1968bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/nestedif/clang/nestedif.expected
+++ b/src/test/correct/nestedif/clang/nestedif.expected
@@ -96,7 +96,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/nestedif/clang_O2/nestedif.expected
+++ b/src/test/correct/nestedif/clang_O2/nestedif.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1840bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/nestedif/clang_O2/nestedif.expected
+++ b/src/test/correct/nestedif/clang_O2/nestedif.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/nestedif/clang_no_plt_no_pic/nestedif.expected
+++ b/src/test/correct/nestedif/clang_no_plt_no_pic/nestedif.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1968bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/nestedif/clang_no_plt_no_pic/nestedif.expected
+++ b/src/test/correct/nestedif/clang_no_plt_no_pic/nestedif.expected
@@ -96,7 +96,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/nestedif/clang_pic/nestedif.expected
+++ b/src/test/correct/nestedif/clang_pic/nestedif.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1968bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/nestedif/clang_pic/nestedif.expected
+++ b/src/test/correct/nestedif/clang_pic/nestedif.expected
@@ -96,7 +96,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/nestedif/gcc/nestedif.expected
+++ b/src/test/correct/nestedif/gcc/nestedif.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/nestedif/gcc/nestedif.expected
+++ b/src/test/correct/nestedif/gcc/nestedif.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1928bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/nestedif/gcc_O2/nestedif.expected
+++ b/src/test/correct/nestedif/gcc_O2/nestedif.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/nestedif/gcc_O2/nestedif.expected
+++ b/src/test/correct/nestedif/gcc_O2/nestedif.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/nestedif/gcc_no_plt_no_pic/nestedif.expected
+++ b/src/test/correct/nestedif/gcc_no_plt_no_pic/nestedif.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/nestedif/gcc_no_plt_no_pic/nestedif.expected
+++ b/src/test/correct/nestedif/gcc_no_plt_no_pic/nestedif.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1928bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/nestedif/gcc_pic/nestedif.expected
+++ b/src/test/correct/nestedif/gcc_pic/nestedif.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/nestedif/gcc_pic/nestedif.expected
+++ b/src/test/correct/nestedif/gcc_pic/nestedif.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1928bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/no_interference_update_x/clang/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/clang/no_interference_update_x.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }

--- a/src/test/correct/no_interference_update_x/clang_O2/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/clang_O2/no_interference_update_x.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }

--- a/src/test/correct/no_interference_update_x/clang_no_plt_no_pic/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/clang_no_plt_no_pic/no_interference_update_x.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }

--- a/src/test/correct/no_interference_update_x/clang_pic/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/clang_pic/no_interference_update_x.expected
@@ -40,7 +40,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -89,7 +89,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -102,7 +102,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }

--- a/src/test/correct/no_interference_update_x/gcc/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/gcc/no_interference_update_x.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }

--- a/src/test/correct/no_interference_update_x/gcc_O2/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/gcc_O2/no_interference_update_x.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }

--- a/src/test/correct/no_interference_update_x/gcc_no_plt_no_pic/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/gcc_no_plt_no_pic/no_interference_update_x.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }

--- a/src/test/correct/no_interference_update_x/gcc_pic/no_interference_update_x.expected
+++ b/src/test/correct/no_interference_update_x/gcc_pic/no_interference_update_x.expected
@@ -38,7 +38,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -87,7 +87,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -100,7 +100,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $y_addr) == memory_load32_le(mem, $y_addr));
 }

--- a/src/test/correct/no_interference_update_y/clang/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/clang/no_interference_update_y.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
 }

--- a/src/test/correct/no_interference_update_y/clang_O2/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/clang_O2/no_interference_update_y.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
 }

--- a/src/test/correct/no_interference_update_y/clang_no_plt_no_pic/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/clang_no_plt_no_pic/no_interference_update_y.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
 }

--- a/src/test/correct/no_interference_update_y/clang_pic/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/clang_pic/no_interference_update_y.expected
@@ -40,7 +40,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -89,7 +89,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
   call rely();
@@ -102,7 +102,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
 }

--- a/src/test/correct/no_interference_update_y/gcc/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/gcc/no_interference_update_y.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
 }

--- a/src/test/correct/no_interference_update_y/gcc_O2/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/gcc_O2/no_interference_update_y.expected
@@ -32,7 +32,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -73,7 +73,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
   call rely();
@@ -86,7 +86,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
 }

--- a/src/test/correct/no_interference_update_y/gcc_no_plt_no_pic/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/gcc_no_plt_no_pic/no_interference_update_y.expected
@@ -30,7 +30,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -71,7 +71,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
   call rely();
@@ -84,7 +84,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
 }

--- a/src/test/correct/no_interference_update_y/gcc_pic/no_interference_update_y.expected
+++ b/src/test/correct/no_interference_update_y/gcc_pic/no_interference_update_y.expected
@@ -38,7 +38,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -87,7 +87,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $y_addr) == old(memory_load32_le(mem, $y_addr)));
 {
   call rely();
@@ -100,7 +100,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr));
 }

--- a/src/test/correct/secret_write/clang/secret_write.expected
+++ b/src/test/correct/secret_write/clang/secret_write.expected
@@ -44,7 +44,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
@@ -101,7 +101,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert bvsge32(memory_load32_le(mem, $z_addr), memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/secret_write/clang_O2/secret_write.expected
+++ b/src/test/correct/secret_write/clang_O2/secret_write.expected
@@ -42,7 +42,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
@@ -99,7 +99,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert bvsge32(memory_load32_le(mem, $z_addr), memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/secret_write/clang_no_plt_no_pic/secret_write.expected
+++ b/src/test/correct/secret_write/clang_no_plt_no_pic/secret_write.expected
@@ -44,7 +44,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
@@ -101,7 +101,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert bvsge32(memory_load32_le(mem, $z_addr), memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/secret_write/clang_pic/secret_write.expected
+++ b/src/test/correct/secret_write/clang_pic/secret_write.expected
@@ -52,7 +52,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
@@ -118,7 +118,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69567bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
@@ -133,7 +133,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert bvsge32(memory_load32_le(mem, $z_addr), memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/secret_write/gcc/secret_write.expected
+++ b/src/test/correct/secret_write/gcc/secret_write.expected
@@ -40,7 +40,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
@@ -97,7 +97,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert bvsge32(memory_load32_le(mem, $z_addr), memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/secret_write/gcc_O2/secret_write.expected
+++ b/src/test/correct/secret_write/gcc_O2/secret_write.expected
@@ -42,7 +42,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
@@ -99,7 +99,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert bvsge32(memory_load32_le(mem, $z_addr), memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/secret_write/gcc_no_plt_no_pic/secret_write.expected
+++ b/src/test/correct/secret_write/gcc_no_plt_no_pic/secret_write.expected
@@ -40,7 +40,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
@@ -97,7 +97,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert bvsge32(memory_load32_le(mem, $z_addr), memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/secret_write/gcc_pic/secret_write.expected
+++ b/src/test/correct/secret_write/gcc_pic/secret_write.expected
@@ -48,7 +48,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
@@ -114,7 +114,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 68999bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $z_addr) == old(memory_load32_le(mem, $z_addr)));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
@@ -129,7 +129,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert bvsge32(memory_load32_le(mem, $z_addr), memory_load32_le(mem, $z_addr));
 }

--- a/src/test/correct/simple_jump/clang/simple_jump.expected
+++ b/src/test/correct/simple_jump/clang/simple_jump.expected
@@ -96,7 +96,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/simple_jump/clang/simple_jump.expected
+++ b/src/test/correct/simple_jump/clang/simple_jump.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/simple_jump/clang_O2/simple_jump.expected
+++ b/src/test/correct/simple_jump/clang_O2/simple_jump.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1840bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/simple_jump/clang_O2/simple_jump.expected
+++ b/src/test/correct/simple_jump/clang_O2/simple_jump.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/simple_jump/clang_no_plt_no_pic/simple_jump.expected
+++ b/src/test/correct/simple_jump/clang_no_plt_no_pic/simple_jump.expected
@@ -96,7 +96,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/simple_jump/clang_no_plt_no_pic/simple_jump.expected
+++ b/src/test/correct/simple_jump/clang_no_plt_no_pic/simple_jump.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/simple_jump/clang_pic/simple_jump.expected
+++ b/src/test/correct/simple_jump/clang_pic/simple_jump.expected
@@ -96,7 +96,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/simple_jump/clang_pic/simple_jump.expected
+++ b/src/test/correct/simple_jump/clang_pic/simple_jump.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/correct/simple_jump/gcc/simple_jump.expected
+++ b/src/test/correct/simple_jump/gcc/simple_jump.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1876bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/simple_jump/gcc/simple_jump.expected
+++ b/src/test/correct/simple_jump/gcc/simple_jump.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/simple_jump/gcc_O2/simple_jump.expected
+++ b/src/test/correct/simple_jump/gcc_O2/simple_jump.expected
@@ -9,7 +9,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -50,7 +50,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -61,7 +61,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, R0;

--- a/src/test/correct/simple_jump/gcc_O2/simple_jump.expected
+++ b/src/test/correct/simple_jump/gcc_O2/simple_jump.expected
@@ -64,7 +64,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/simple_jump/gcc_no_plt_no_pic/simple_jump.expected
+++ b/src/test/correct/simple_jump/gcc_no_plt_no_pic/simple_jump.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1876bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/simple_jump/gcc_no_plt_no_pic/simple_jump.expected
+++ b/src/test/correct/simple_jump/gcc_no_plt_no_pic/simple_jump.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/simple_jump/gcc_pic/simple_jump.expected
+++ b/src/test/correct/simple_jump/gcc_pic/simple_jump.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1876bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/simple_jump/gcc_pic/simple_jump.expected
+++ b/src/test/correct/simple_jump/gcc_pic/simple_jump.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/switch/clang/switch.expected
+++ b/src/test/correct/switch/clang/switch.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R31, R8, mem, stack;
+  modifies Gamma_R31, Gamma_R8, Gamma_stack, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/switch/clang/switch.expected
+++ b/src/test/correct/switch/clang/switch.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1936bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R31, Gamma_R8, Gamma_stack, R31, R8, stack;

--- a/src/test/correct/switch/clang_O2/switch.expected
+++ b/src/test/correct/switch/clang_O2/switch.expected
@@ -7,7 +7,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1836bv64) == 1bv8);
@@ -48,7 +48,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -59,7 +59,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);

--- a/src/test/correct/switch/clang_O2/switch.expected
+++ b/src/test/correct/switch/clang_O2/switch.expected
@@ -62,7 +62,6 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_mem, mem;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/switch/clang_no_plt_no_pic/switch.expected
+++ b/src/test/correct/switch/clang_no_plt_no_pic/switch.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R31, R8, mem, stack;
+  modifies Gamma_R31, Gamma_R8, Gamma_stack, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/switch/clang_no_plt_no_pic/switch.expected
+++ b/src/test/correct/switch/clang_no_plt_no_pic/switch.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1936bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R31, Gamma_R8, Gamma_stack, R31, R8, stack;

--- a/src/test/correct/switch/clang_pic/switch.expected
+++ b/src/test/correct/switch/clang_pic/switch.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R31, R8, mem, stack;
+  modifies Gamma_R31, Gamma_R8, Gamma_stack, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/correct/switch/clang_pic/switch.expected
+++ b/src/test/correct/switch/clang_pic/switch.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1936bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R31, Gamma_R8, Gamma_stack, R31, R8, stack;

--- a/src/test/correct/switch/gcc/switch.expected
+++ b/src/test/correct/switch/gcc/switch.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/switch/gcc/switch.expected
+++ b/src/test/correct/switch/gcc/switch.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/switch/gcc_O2/switch.expected
+++ b/src/test/correct/switch/gcc_O2/switch.expected
@@ -7,7 +7,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -48,7 +48,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -59,7 +59,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);

--- a/src/test/correct/switch/gcc_O2/switch.expected
+++ b/src/test/correct/switch/gcc_O2/switch.expected
@@ -62,7 +62,6 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_mem, mem;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/switch/gcc_no_plt_no_pic/switch.expected
+++ b/src/test/correct/switch/gcc_no_plt_no_pic/switch.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/switch/gcc_no_plt_no_pic/switch.expected
+++ b/src/test/correct/switch/gcc_no_plt_no_pic/switch.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/switch/gcc_pic/switch.expected
+++ b/src/test/correct/switch/gcc_pic/switch.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/correct/switch/gcc_pic/switch.expected
+++ b/src/test/correct/switch/gcc_pic/switch.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/switch2/clang_O2/switch2.expected
+++ b/src/test/correct/switch2/clang_O2/switch2.expected
@@ -6,7 +6,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1844bv64) == 1bv8);
@@ -47,7 +47,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -58,7 +58,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   requires (Gamma_R0 == true);

--- a/src/test/correct/switch2/clang_O2/switch2.expected
+++ b/src/test/correct/switch2/clang_O2/switch2.expected
@@ -61,7 +61,6 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_mem, mem;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/switch2/gcc/switch2.expected
+++ b/src/test/correct/switch2/gcc/switch2.expected
@@ -115,7 +115,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
@@ -377,7 +377,7 @@ procedure main()
 }
 
 procedure r()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 2032bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2033bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2034bv64) == 2bv8);

--- a/src/test/correct/switch2/gcc/switch2.expected
+++ b/src/test/correct/switch2/gcc/switch2.expected
@@ -60,7 +60,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2032bv64) == 1bv8);
@@ -101,7 +101,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -112,7 +112,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;

--- a/src/test/correct/switch2/gcc_O2/switch2.expected
+++ b/src/test/correct/switch2/gcc_O2/switch2.expected
@@ -61,7 +61,6 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_mem, mem;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/switch2/gcc_O2/switch2.expected
+++ b/src/test/correct/switch2/gcc_O2/switch2.expected
@@ -6,7 +6,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -47,7 +47,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -58,7 +58,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   requires (Gamma_R0 == true);

--- a/src/test/correct/switch2/gcc_no_plt_no_pic/switch2.expected
+++ b/src/test/correct/switch2/gcc_no_plt_no_pic/switch2.expected
@@ -115,7 +115,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
@@ -377,7 +377,7 @@ procedure main()
 }
 
 procedure r()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 2032bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2033bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2034bv64) == 2bv8);

--- a/src/test/correct/switch2/gcc_no_plt_no_pic/switch2.expected
+++ b/src/test/correct/switch2/gcc_no_plt_no_pic/switch2.expected
@@ -60,7 +60,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2032bv64) == 1bv8);
@@ -101,7 +101,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -112,7 +112,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;

--- a/src/test/correct/switch2/gcc_pic/switch2.expected
+++ b/src/test/correct/switch2/gcc_pic/switch2.expected
@@ -115,7 +115,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;
   requires (Gamma_R0 == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
@@ -377,7 +377,7 @@ procedure main()
 }
 
 procedure r()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0;
   free requires (memory_load8_le(mem, 2032bv64) == 1bv8);
   free requires (memory_load8_le(mem, 2033bv64) == 0bv8);
   free requires (memory_load8_le(mem, 2034bv64) == 2bv8);

--- a/src/test/correct/switch2/gcc_pic/switch2.expected
+++ b/src/test/correct/switch2/gcc_pic/switch2.expected
@@ -60,7 +60,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2032bv64) == 1bv8);
@@ -101,7 +101,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -112,7 +112,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R29, R30, R31, stack;

--- a/src/test/correct/syscall/clang/syscall.expected
+++ b/src/test/correct/syscall/clang/syscall.expected
@@ -57,7 +57,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1944bv64) == 1bv8);
@@ -98,7 +98,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -109,7 +109,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure fork();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/syscall/clang/syscall.expected
+++ b/src/test/correct/syscall/clang/syscall.expected
@@ -112,7 +112,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure fork();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1944bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1945bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1946bv64) == 2bv8);
@@ -187,7 +187,7 @@ procedure fork();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69672bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69673bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69674bv64) == 0bv8);

--- a/src/test/correct/syscall/clang_no_plt_no_pic/syscall.expected
+++ b/src/test/correct/syscall/clang_no_plt_no_pic/syscall.expected
@@ -57,7 +57,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1944bv64) == 1bv8);
@@ -98,7 +98,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -109,7 +109,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure fork();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/syscall/clang_no_plt_no_pic/syscall.expected
+++ b/src/test/correct/syscall/clang_no_plt_no_pic/syscall.expected
@@ -112,7 +112,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure fork();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1944bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1945bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1946bv64) == 2bv8);
@@ -187,7 +187,7 @@ procedure fork();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69672bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69673bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69674bv64) == 0bv8);

--- a/src/test/correct/syscall/clang_pic/syscall.expected
+++ b/src/test/correct/syscall/clang_pic/syscall.expected
@@ -57,7 +57,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1944bv64) == 1bv8);
@@ -98,7 +98,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -109,7 +109,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure fork();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/syscall/clang_pic/syscall.expected
+++ b/src/test/correct/syscall/clang_pic/syscall.expected
@@ -112,7 +112,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure fork();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1944bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1945bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1946bv64) == 2bv8);
@@ -187,7 +187,7 @@ procedure fork();
   free ensures (memory_load8_le(mem, 69687bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69672bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69673bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69674bv64) == 0bv8);

--- a/src/test/correct/syscall/gcc/syscall.expected
+++ b/src/test/correct/syscall/gcc/syscall.expected
@@ -112,7 +112,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure fork();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
@@ -187,7 +187,7 @@ procedure fork();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/syscall/gcc/syscall.expected
+++ b/src/test/correct/syscall/gcc/syscall.expected
@@ -57,7 +57,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -98,7 +98,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -109,7 +109,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure fork();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/syscall/gcc_O2/syscall.expected
+++ b/src/test/correct/syscall/gcc_O2/syscall.expected
@@ -11,7 +11,7 @@ function memory_load8_le(memory: [bv64]bv8, index: bv64) returns (bv8) {
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1960bv64) == 1bv8);
@@ -52,7 +52,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -63,7 +63,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure fork();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/syscall/gcc_O2/syscall.expected
+++ b/src/test/correct/syscall/gcc_O2/syscall.expected
@@ -66,7 +66,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure fork();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/syscall/gcc_no_plt_no_pic/syscall.expected
+++ b/src/test/correct/syscall/gcc_no_plt_no_pic/syscall.expected
@@ -112,7 +112,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure fork();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
@@ -187,7 +187,7 @@ procedure fork();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/syscall/gcc_no_plt_no_pic/syscall.expected
+++ b/src/test/correct/syscall/gcc_no_plt_no_pic/syscall.expected
@@ -57,7 +57,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -98,7 +98,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -109,7 +109,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure fork();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/syscall/gcc_pic/syscall.expected
+++ b/src/test/correct/syscall/gcc_pic/syscall.expected
@@ -112,7 +112,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure fork();
-  modifies Gamma_R16, Gamma_R17, Gamma_mem, R16, R17, mem;
+  modifies Gamma_R16, Gamma_R17, R16, R17;
   free requires (memory_load8_le(mem, 1932bv64) == 1bv8);
   free requires (memory_load8_le(mem, 1933bv64) == 0bv8);
   free requires (memory_load8_le(mem, 1934bv64) == 2bv8);
@@ -187,7 +187,7 @@ procedure fork();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure main()
-  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_mem, Gamma_stack, R0, R16, R17, R29, R30, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R16, Gamma_R17, Gamma_R29, Gamma_R30, Gamma_R31, Gamma_stack, R0, R16, R17, R29, R30, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/correct/syscall/gcc_pic/syscall.expected
+++ b/src/test/correct/syscall/gcc_pic/syscall.expected
@@ -57,7 +57,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -98,7 +98,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -109,7 +109,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure fork();
   modifies Gamma_R16, Gamma_R17, R16, R17;

--- a/src/test/correct/using_gamma_conditional/clang/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang/using_gamma_conditional.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/clang/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang/using_gamma_conditional.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
   call rely();
@@ -101,13 +101,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/clang_O2/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_O2/using_gamma_conditional.expected
@@ -35,7 +35,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -76,7 +76,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
   call rely();
@@ -89,13 +89,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, R0, R8, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R8, Gamma_mem, R0, R8, mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/clang_O2/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_O2/using_gamma_conditional.expected
@@ -95,7 +95,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R8, Gamma_mem, R0, R8, mem;
+  modifies Gamma_R0, Gamma_R8, R0, R8, mem, Gamma_mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/clang_no_plt_no_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_no_plt_no_pic/using_gamma_conditional.expected
@@ -107,7 +107,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/clang_no_plt_no_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_no_plt_no_pic/using_gamma_conditional.expected
@@ -47,7 +47,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -88,7 +88,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
   call rely();
@@ -101,13 +101,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/clang_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_pic/using_gamma_conditional.expected
@@ -123,7 +123,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/clang_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/clang_pic/using_gamma_conditional.expected
@@ -55,7 +55,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -104,7 +104,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
   call rely();
@@ -117,13 +117,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/gcc/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc/using_gamma_conditional.expected
@@ -33,7 +33,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -74,7 +74,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
   call rely();
@@ -87,13 +87,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, R0, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_mem, R0, mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/gcc/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc/using_gamma_conditional.expected
@@ -93,7 +93,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0, mem, Gamma_mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/gcc_O2/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc_O2/using_gamma_conditional.expected
@@ -93,7 +93,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0, mem, Gamma_mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/gcc_O2/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc_O2/using_gamma_conditional.expected
@@ -33,7 +33,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -74,7 +74,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
   call rely();
@@ -87,13 +87,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, R0, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_mem, R0, mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/gcc_no_plt_no_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc_no_plt_no_pic/using_gamma_conditional.expected
@@ -33,7 +33,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
   free ensures (memory_load8_le(mem, 1868bv64) == 1bv8);
@@ -74,7 +74,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
   call rely();
@@ -87,13 +87,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, R0, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_mem, R0, mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/gcc_no_plt_no_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc_no_plt_no_pic/using_gamma_conditional.expected
@@ -93,7 +93,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0, mem, Gamma_mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/gcc_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc_pic/using_gamma_conditional.expected
@@ -41,7 +41,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
   free ensures (memory_load8_le(mem, 1932bv64) == 1bv8);
@@ -90,7 +90,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (old(gamma_load32(Gamma_mem, $x_addr)) ==> gamma_load32(Gamma_mem, $x_addr));
 {
   call rely();
@@ -103,13 +103,13 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert ((memory_load32_le(mem, $x_addr) == memory_load32_le(mem, $x_addr)) && (memory_load32_le(mem, $z_addr) == memory_load32_le(mem, $z_addr)));
 }
 
 procedure main()
-  modifies Gamma_R0, R0, mem, Gamma_mem;
+  modifies Gamma_R0, Gamma_mem, R0, mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/using_gamma_conditional/gcc_pic/using_gamma_conditional.expected
+++ b/src/test/correct/using_gamma_conditional/gcc_pic/using_gamma_conditional.expected
@@ -109,7 +109,7 @@ procedure guarantee_reflexive()
 }
 
 procedure main()
-  modifies Gamma_R0, Gamma_mem, R0, mem;
+  modifies Gamma_R0, R0, mem, Gamma_mem;
   requires (gamma_load32(Gamma_mem, $x_addr) == true);
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);

--- a/src/test/correct/using_gamma_write_z/clang/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/clang/using_gamma_write_z.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
 }

--- a/src/test/correct/using_gamma_write_z/clang_O2/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/clang_O2/using_gamma_write_z.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
 }

--- a/src/test/correct/using_gamma_write_z/clang_no_plt_no_pic/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/clang_no_plt_no_pic/using_gamma_write_z.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1852bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
 }

--- a/src/test/correct/using_gamma_write_z/clang_pic/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/clang_pic/using_gamma_write_z.expected
@@ -44,7 +44,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -93,7 +93,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69599bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -106,7 +106,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
 }

--- a/src/test/correct/using_gamma_write_z/gcc/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/gcc/using_gamma_write_z.expected
@@ -34,7 +34,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -75,7 +75,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -88,7 +88,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
 }

--- a/src/test/correct/using_gamma_write_z/gcc_O2/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/gcc_O2/using_gamma_write_z.expected
@@ -36,7 +36,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -90,7 +90,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
 }

--- a/src/test/correct/using_gamma_write_z/gcc_no_plt_no_pic/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/gcc_no_plt_no_pic/using_gamma_write_z.expected
@@ -34,7 +34,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -75,7 +75,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -88,7 +88,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
 }

--- a/src/test/correct/using_gamma_write_z/gcc_pic/using_gamma_write_z.expected
+++ b/src/test/correct/using_gamma_write_z/gcc_pic/using_gamma_write_z.expected
@@ -42,7 +42,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
   free ensures (memory_load8_le(mem, 1920bv64) == 1bv8);
@@ -91,7 +91,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69015bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures ((old(memory_load32_le(mem, $x_addr)) == memory_load32_le(mem, $x_addr)) && (old(memory_load32_le(mem, $z_addr)) == memory_load32_le(mem, $z_addr)));
 {
   call rely();
@@ -104,7 +104,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 {
   assert (gamma_load32(Gamma_mem, $x_addr) ==> gamma_load32(Gamma_mem, $x_addr));
 }

--- a/src/test/incorrect/basicassign/clang/basicassign.expected
+++ b/src/test/incorrect/basicassign/clang/basicassign.expected
@@ -43,7 +43,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1888bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -97,7 +97,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R11, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R11, R8, R9, mem;

--- a/src/test/incorrect/basicassign/clang_O2/basicassign.expected
+++ b/src/test/incorrect/basicassign/clang_O2/basicassign.expected
@@ -41,7 +41,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1864bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -95,7 +95,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R8, R9, mem;

--- a/src/test/incorrect/basicassign/clang_no_plt_no_pic/basicassign.expected
+++ b/src/test/incorrect/basicassign/clang_no_plt_no_pic/basicassign.expected
@@ -43,7 +43,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1888bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -97,7 +97,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R11, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R11, R8, R9, mem;

--- a/src/test/incorrect/basicassign/clang_pic/basicassign.expected
+++ b/src/test/incorrect/basicassign/clang_pic/basicassign.expected
@@ -51,7 +51,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -116,7 +116,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69567bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -129,7 +129,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R11, Gamma_R8, Gamma_R9, Gamma_mem, R0, R10, R11, R8, R9, mem;

--- a/src/test/incorrect/basicassign/gcc/basicassign.expected
+++ b/src/test/incorrect/basicassign/gcc/basicassign.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1948bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/incorrect/basicassign/gcc_O2/basicassign.expected
+++ b/src/test/incorrect/basicassign/gcc_O2/basicassign.expected
@@ -39,7 +39,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -93,7 +93,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;

--- a/src/test/incorrect/basicassign/gcc_no_plt_no_pic/basicassign.expected
+++ b/src/test/incorrect/basicassign/gcc_no_plt_no_pic/basicassign.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 1948bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -91,7 +91,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/incorrect/basicassign/gcc_pic/basicassign.expected
+++ b/src/test/incorrect/basicassign/gcc_pic/basicassign.expected
@@ -45,7 +45,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (forall i: bv64 :: (((mem[i] == old(mem[i])) ==> (Gamma_mem[i] == old(Gamma_mem[i])))));
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
   free ensures (memory_load8_le(mem, 2012bv64) == 1bv8);
@@ -110,7 +110,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 68999bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (memory_load32_le(mem, $x_addr) == old(memory_load32_le(mem, $x_addr)));
 {
   call rely();
@@ -123,7 +123,7 @@ procedure rely_reflexive()
 }
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_mem, R0, R1, mem;

--- a/src/test/incorrect/basicassign1/clang/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/clang/basicassign1.expected
@@ -41,7 +41,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign1/clang_O2/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/clang_O2/basicassign1.expected
@@ -35,7 +35,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -76,7 +76,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -87,7 +87,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/incorrect/basicassign1/clang_no_plt_no_pic/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/clang_no_plt_no_pic/basicassign1.expected
@@ -41,7 +41,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -82,7 +82,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -93,7 +93,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign1/clang_pic/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/clang_pic/basicassign1.expected
@@ -49,7 +49,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -106,7 +106,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -117,7 +117,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign1/gcc/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/gcc/basicassign1.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -89,7 +89,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/basicassign1/gcc_O2/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/gcc_O2/basicassign1.expected
@@ -35,7 +35,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -76,7 +76,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -87,7 +87,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;

--- a/src/test/incorrect/basicassign1/gcc_no_plt_no_pic/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/gcc_no_plt_no_pic/basicassign1.expected
@@ -37,7 +37,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -89,7 +89,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/basicassign1/gcc_pic/basicassign1.expected
+++ b/src/test/incorrect/basicassign1/gcc_pic/basicassign1.expected
@@ -45,7 +45,7 @@ function memory_store32_le(memory: [bv64]bv8, index: bv64, value: bv32) returns 
 
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1980bv64) == 1bv8);
@@ -102,7 +102,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -113,7 +113,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/basicassign2/clang/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/clang/basicassign2.expected
@@ -42,7 +42,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -83,7 +83,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -94,7 +94,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign2/clang_O2/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/clang_O2/basicassign2.expected
@@ -36,7 +36,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -88,7 +88,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/incorrect/basicassign2/clang_no_plt_no_pic/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/clang_no_plt_no_pic/basicassign2.expected
@@ -42,7 +42,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -83,7 +83,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -94,7 +94,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign2/clang_pic/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/clang_pic/basicassign2.expected
@@ -42,7 +42,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -99,7 +99,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -110,7 +110,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign2/gcc/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/gcc/basicassign2.expected
@@ -38,7 +38,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -79,7 +79,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -90,7 +90,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/basicassign2/gcc_O2/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/gcc_O2/basicassign2.expected
@@ -36,7 +36,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -77,7 +77,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -88,7 +88,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;

--- a/src/test/incorrect/basicassign2/gcc_no_plt_no_pic/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/gcc_no_plt_no_pic/basicassign2.expected
@@ -38,7 +38,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -79,7 +79,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -90,7 +90,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/basicassign2/gcc_pic/basicassign2.expected
+++ b/src/test/incorrect/basicassign2/gcc_pic/basicassign2.expected
@@ -38,7 +38,7 @@ function memory_store64_le(memory: [bv64]bv8, index: bv64, value: bv64) returns 
 }
 
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1980bv64) == 1bv8);
@@ -95,7 +95,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -106,7 +106,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/basicassign3/clang/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/clang/basicassign3.expected
@@ -39,7 +39,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign3/clang_O2/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/clang_O2/basicassign3.expected
@@ -33,7 +33,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1856bv64) == 1bv8);
@@ -74,7 +74,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -85,7 +85,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R8, Gamma_R9, Gamma_mem, R0, R8, R9, mem;

--- a/src/test/incorrect/basicassign3/clang_no_plt_no_pic/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/clang_no_plt_no_pic/basicassign3.expected
@@ -39,7 +39,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1892bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign3/clang_pic/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/clang_pic/basicassign3.expected
@@ -47,7 +47,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1964bv64) == 1bv8);
@@ -104,7 +104,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -115,7 +115,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R10, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R10, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/basicassign3/gcc/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/gcc/basicassign3.expected
@@ -35,7 +35,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -76,7 +76,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -87,7 +87,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/basicassign3/gcc_O2/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/gcc_O2/basicassign3.expected
@@ -33,7 +33,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -74,7 +74,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -85,7 +85,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R2, Gamma_mem, R0, R1, R2, mem;

--- a/src/test/incorrect/basicassign3/gcc_no_plt_no_pic/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/gcc_no_plt_no_pic/basicassign3.expected
@@ -35,7 +35,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1916bv64) == 1bv8);
@@ -76,7 +76,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -87,7 +87,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/basicassign3/gcc_pic/basicassign3.expected
+++ b/src/test/incorrect/basicassign3/gcc_pic/basicassign3.expected
@@ -43,7 +43,7 @@ function memory_store8_le(memory: [bv64]bv8, index: bv64, value: bv8) returns ([
 
 function {:bvbuiltin "zero_extend 56"} zero_extend56_8(bv8) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1980bv64) == 1bv8);
@@ -100,7 +100,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -111,7 +111,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/iflocal/clang/iflocal.expected
+++ b/src/test/incorrect/iflocal/clang/iflocal.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/incorrect/iflocal/clang/iflocal.expected
+++ b/src/test/incorrect/iflocal/clang/iflocal.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/incorrect/iflocal/clang_no_plt_no_pic/iflocal.expected
+++ b/src/test/incorrect/iflocal/clang_no_plt_no_pic/iflocal.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/incorrect/iflocal/clang_no_plt_no_pic/iflocal.expected
+++ b/src/test/incorrect/iflocal/clang_no_plt_no_pic/iflocal.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/incorrect/iflocal/clang_pic/iflocal.expected
+++ b/src/test/incorrect/iflocal/clang_pic/iflocal.expected
@@ -94,7 +94,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_mem, Gamma_stack, R0, R31, R8, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;
   free requires (memory_load8_le(mem, 69664bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69665bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69666bv64) == 0bv8);

--- a/src/test/incorrect/iflocal/clang_pic/iflocal.expected
+++ b/src/test/incorrect/iflocal/clang_pic/iflocal.expected
@@ -39,7 +39,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1896bv64) == 1bv8);
@@ -80,7 +80,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -91,7 +91,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_stack, R0, R31, R8, stack;

--- a/src/test/incorrect/iflocal/gcc/iflocal.expected
+++ b/src/test/incorrect/iflocal/gcc/iflocal.expected
@@ -92,7 +92,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/incorrect/iflocal/gcc/iflocal.expected
+++ b/src/test/incorrect/iflocal/gcc/iflocal.expected
@@ -37,7 +37,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1880bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -89,7 +89,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/incorrect/iflocal/gcc_no_plt_no_pic/iflocal.expected
+++ b/src/test/incorrect/iflocal/gcc_no_plt_no_pic/iflocal.expected
@@ -92,7 +92,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/incorrect/iflocal/gcc_no_plt_no_pic/iflocal.expected
+++ b/src/test/incorrect/iflocal/gcc_no_plt_no_pic/iflocal.expected
@@ -37,7 +37,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1880bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -89,7 +89,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/incorrect/iflocal/gcc_pic/iflocal.expected
+++ b/src/test/incorrect/iflocal/gcc_pic/iflocal.expected
@@ -92,7 +92,7 @@ procedure guarantee_reflexive();
   modifies mem, Gamma_mem;
 
 procedure main()
-  modifies Gamma_R0, Gamma_R31, Gamma_mem, Gamma_stack, R0, R31, mem, stack;
+  modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;
   free requires (memory_load8_le(mem, 69632bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69633bv64) == 0bv8);
   free requires (memory_load8_le(mem, 69634bv64) == 0bv8);

--- a/src/test/incorrect/iflocal/gcc_pic/iflocal.expected
+++ b/src/test/incorrect/iflocal/gcc_pic/iflocal.expected
@@ -37,7 +37,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1880bv64) == 1bv8);
@@ -78,7 +78,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -89,7 +89,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_stack, R0, R31, stack;

--- a/src/test/incorrect/nestedifglobal/clang/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/clang/nestedifglobal.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1976bv64) == 1bv8);
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -97,7 +97,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/nestedifglobal/clang_no_plt_no_pic/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/clang_no_plt_no_pic/nestedifglobal.expected
@@ -45,7 +45,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1976bv64) == 1bv8);
@@ -86,7 +86,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69679bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -97,7 +97,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/nestedifglobal/clang_pic/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/clang_pic/nestedifglobal.expected
@@ -61,7 +61,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2052bv64) == 1bv8);
@@ -118,7 +118,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69063bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -129,7 +129,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R31, Gamma_R8, Gamma_R9, Gamma_mem, Gamma_stack, R0, R31, R8, R9, mem, stack;

--- a/src/test/incorrect/nestedifglobal/gcc/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/gcc/nestedifglobal.expected
@@ -43,7 +43,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1956bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -95,7 +95,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/nestedifglobal/gcc_no_plt_no_pic/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/gcc_no_plt_no_pic/nestedifglobal.expected
@@ -43,7 +43,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 1956bv64) == 1bv8);
@@ -84,7 +84,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69647bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -95,7 +95,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;

--- a/src/test/incorrect/nestedifglobal/gcc_pic/nestedifglobal.expected
+++ b/src/test/incorrect/nestedifglobal/gcc_pic/nestedifglobal.expected
@@ -51,7 +51,7 @@ function {:bvbuiltin "sign_extend 1"} sign_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 1"} zero_extend1_32(bv32) returns (bv33);
 function {:bvbuiltin "zero_extend 32"} zero_extend32_32(bv32) returns (bv64);
 procedure rely();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
   free ensures (memory_load8_le(mem, 2020bv64) == 1bv8);
@@ -108,7 +108,7 @@ procedure rely();
   free ensures (memory_load8_le(mem, 69007bv64) == 0bv8);
 
 procedure rely_transitive()
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
   ensures (mem == old(mem));
   ensures (Gamma_mem == old(Gamma_mem));
 {
@@ -119,7 +119,7 @@ procedure rely_transitive()
 procedure rely_reflexive();
 
 procedure guarantee_reflexive();
-  modifies mem, Gamma_mem;
+  modifies Gamma_mem, mem;
 
 procedure main()
   modifies Gamma_R0, Gamma_R1, Gamma_R31, Gamma_mem, Gamma_stack, R0, R1, R31, mem, stack;


### PR DESCRIPTION
- Fixes https://github.com/UQ-PAC/bil-to-boogie-translator/issues/111 by pushing all the values in the modifies clause up the call tree of the boogie program, right at the end of generation instead of always inserting an extra mem for the rely().
- Also renames "boogie.ProcedureCall" to "boogie.BProcedureCall".

This implementation is fairly inefficient, @l-kent you referred to a broader refactor to do something like this but I'm not sure what you had in mind for that. 

