### PR TITLE
Analysis Cleanup and Explicit Types

### DIFF
--- a/src/main/scala/analysis/Analysis.scala
+++ b/src/main/scala/analysis/Analysis.scala
@@ -170,6 +170,8 @@ trait MemoryRegionAnalysis(val cfg: ProgramCfg,
 
   val domain: Set[CfgNode] = cfg.nodes.toSet
 
+  val first: Set[CfgNode] = domain.collect { case n: CfgFunctionEntryNode if n.predIntra.isEmpty => n }
+
   private val stackPointer = Register("R31", BitVecType(64))
   private val linkRegister = Register("R30", BitVecType(64))
   private val framePointer = Register("R29", BitVecType(64))
@@ -316,4 +318,5 @@ class MemoryRegionAnalysisSolver(
     subroutines: Map[BigInt, String],
     constantProp: Map[CfgNode, Map[Variable, FlatElement[BitVecLiteral]]]
 ) extends MemoryRegionAnalysis(cfg, globals, globalOffsets, subroutines, constantProp)
-    with IntraproceduralMonotonicSolver[Set[MemoryRegion], PowersetLattice[MemoryRegion]]
+    with IntraproceduralForwardDependencies
+    with SimpleMonotonicSolver[CfgNode, Set[MemoryRegion], PowersetLattice[MemoryRegion]]

--- a/src/main/scala/analysis/Analysis.scala
+++ b/src/main/scala/analysis/Analysis.scala
@@ -18,7 +18,7 @@ trait Analysis[+R]:
 
   /** Performs the analysis and returns the result.
     */
-  def analyze(intra: Boolean): R
+  def analyze(): R
 
 /** Base class for value analysis with simple (non-lifted) lattice.
   */
@@ -98,7 +98,7 @@ trait ConstantPropagation(val cfg: ProgramCfg) {
 
 class ConstantPropagationSolver(cfg: ProgramCfg) extends ConstantPropagation(cfg)
     with SimplePushDownWorklistFixpointSolver[CfgNode, Map[Variable, FlatElement[BitVecLiteral]], MapLattice[Variable, FlatElement[BitVecLiteral], ConstantPropagationLattice]]
-    with ForwardDependencies
+    with IntraproceduralForwardDependencies
     with Analysis[Map[CfgNode, Map[Variable, FlatElement[BitVecLiteral]]]]
 
 
@@ -316,5 +316,4 @@ class MemoryRegionAnalysisSolver(
     subroutines: Map[BigInt, String],
     constantProp: Map[CfgNode, Map[Variable, FlatElement[BitVecLiteral]]]
 ) extends MemoryRegionAnalysis(cfg, globals, globalOffsets, subroutines, constantProp)
-    with SimpleMonotonicSolver[CfgNode, Set[MemoryRegion], PowersetLattice[MemoryRegion]]
-    with ForwardDependencies
+    with IntraproceduralMonotonicSolver[Set[MemoryRegion], PowersetLattice[MemoryRegion]]

--- a/src/main/scala/analysis/Cfg.scala
+++ b/src/main/scala/analysis/Cfg.scala
@@ -8,6 +8,8 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.util.control.Breaks.break
 import util.Logger
 
+import scala.annotation.tailrec
+
 /** Node in the control-flow graph.
   */
 object CfgNode:
@@ -17,47 +19,6 @@ object CfgNode:
   def nextId(): Int =
     id += 1
     id
-
-/** Edge type.
-  *
-  * `cond` : condition if this is a conditional edge. By default, assume True.
-  */
-trait CfgEdge(from: CfgNode, to: CfgNode, cond: Expr):
-  def getFrom: CfgNode = from
-  def getTo: CfgNode = to
-  def getCond: Expr = cond
-
-/** Edge between two command nodes in the CFG. Used for `GoTo` branches as well (with a condition added for the branch).
-  */
-case class RegularEdge(from: CfgNode, to: CfgNode, cond: Expr) extends CfgEdge(from, to, cond) {
-  override def toString: String = s"RegularEdge(From: $from, To: $to)"
-}
-
-/** Edge which skips over a procedure call. Used for "jumping over" function calls, i.e. in an intra-procedural CFG
-  * walk.
-  */
-case class IntraprocEdge(from: CfgNode, to: CfgNode, cond: Expr) extends CfgEdge(from, to, cond) {
-  override def toString: String = s"IntraprocEdge(From: $from, To: $to)"
-}
-
-/** Procedure call between node and procedure.
-  */
-class InterprocEdge(from: CfgNode, to: CfgNode, cond: Expr) extends CfgEdge(from, to, cond) {
-  override def toString: String = s"InterprocEdge(From: $from, To: $to)"
-}
-
-/** Connects an intraprocedural cfg with a copy of a another procedure's intraprocedural cfg.
-  */
-case class InlineEdge(from: CfgNode, to: CfgNode, cond: Expr) extends InterprocEdge(from, to, cond) {
-  override def toString: String = s"InlineEdge(From: $from, To: $to)"
-}
-
-/** Connects an intraprocedural cfg with another procedure's intraprocedural cfg, by a direct link. This only applies to
-  * leaf-node calls of a cfg, i.e., if the call is not being inlined.
-  */
-case class InterprocCallEdge(from: CfgNode, to: CfgNode, cond: Expr) extends InterprocEdge(from, to, cond) {
-  override def toString: String = s"InterprocCallEdge(From: $from, To: $to)"
-}
 
 /** Node in the control-flow graph. Each node has a (simple incremental) unique identifier used to distinguish it from
   * other nodes in the cfg - this is mainly used for copying procedure cfgs when inlining them.
@@ -92,99 +53,25 @@ trait CfgNode:
     *
     * `predIntra` <: Set[RegularEdge | IntraprocEdge]
     */
-  val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge]()
+  val predIntra: mutable.Set[CfgNode] = mutable.Set[CfgNode]()
 
   /** Edges to this node from procedure calls. Likely empty unless this node is a [[CfgFunctionEntryNode]]
     *
     * `predInter` <: Set[RegularEdge | InterprocEdge]
     */
-  val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge]()
-
-  /** Retrieve predecessor nodes to this node.
-    *
-    * @param intra
-    *   if true, only walk the intraprocedural cfg.
-    * @return
-    *   Set of predecessor nodes
-    */
-  def pred(intra: Boolean): mutable.Set[CfgNode] = {
-    if intra then
-      predIntra.map(edge => edge.getFrom)
-    else
-      predInter.map(edge => edge.getFrom)
-  }
-
-  /** Retrieve predecessor edges to this node.
-    *
-    * @param intra
-    *   if true, only walk the intraprocedural cfg
-    * @return
-    *   Set of predecessor edges
-    */
-  def predEdges(intra: Boolean): mutable.Set[CfgEdge] = if (intra) predIntra else predInter
-
-  /** Retrieve predecessor nodes and associated conditions, if they exist
-    *
-    * @param intra
-    *   if true, only walk the intraprocedural cfg
-    * @return
-    *   (Node, EdgeCondition)
-    */
-  def predConds(intra: Boolean): mutable.Set[(CfgNode, Expr)] = {
-    if intra then
-      predIntra.map(edge => (edge.getFrom, edge.getCond))
-    else
-      predInter.map(edge => (edge.getFrom, edge.getCond))
-  }
+  val predInter: mutable.Set[CfgNode] = mutable.Set[CfgNode]()
 
   /** Edges to successor nodes, either regular or ignored procedure calls
     *
     * `succIntra` <: Set[RegularEdge | IntraprocEdge]
     */
-  val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge]()
+  val succIntra: mutable.Set[CfgNode] = mutable.Set[CfgNode]()
 
   /** Edges to successor procedure calls. Used when walking inter-proc cfg.
     *
     * `succInter` <: Set[RegularEdge | InterprocEdge]
     */
-  val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge]()
-
-  /** Retrieve successor nodes to this node.
-    *
-    * @param intra
-    *   if true, only walk the intraprocedural cfg.
-    * @return
-    *   Set of successor nodes
-    */
-  def succ(intra: Boolean): mutable.Set[CfgNode] = {
-    if intra then
-      succIntra.map(edge => edge.getTo)
-    else
-      succInter.map(edge => edge.getTo)
-  }
-
-  /** Retrieve successor edges from this node.
-    *
-    * @param intra
-    *   if true, only walk the intraprocedural cfg.
-    * @return
-    *   Set of successor edges
-    */
-  def succEdges(intra: Boolean): mutable.Set[CfgEdge] = if (intra) succIntra else succInter
-
-  /** Retrieve succesor nodes and associated conditions, if they exist.
-    *
-    * @param intra
-    *   if true, only walk the intraprocedural cfg.
-    * @return
-    *   (Node, EdgeCondition)
-    */
-  def succConds(intra: Boolean): mutable.Set[(CfgNode, Expr)] = {
-    if intra then
-      succIntra.map(edge => (edge.getTo, edge.getCond))
-    else
-      succInter.map(edge => (edge.getTo, edge.getCond))
-  }
+  val succInter: mutable.Set[CfgNode] = mutable.Set[CfgNode]()
 
   /** Unique identifier. */
   val id: Int = CfgNode.nextId()
@@ -195,47 +82,29 @@ trait CfgNode:
       case o: CfgNode => o.id == this.id
       case _          => false
 
-  override def hashCode(): Int = id
+  override def hashCode(): Int = id.hashCode()
 
 /** Control-flow graph node that additionally stores an AST node.
   */
-trait CfgNodeWithData[T] extends CfgNode:
-
-  def data: T
-  // Block this node originates from
-  def block: Block
+trait CfgNodeWithData[T] extends CfgNode {
+  val data: T
+}
 
 /** Control-flow graph node for the entry of a function.
   */
-case class CfgFunctionEntryNode(
-    override val id: Int = CfgNode.nextId(),
-    override val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    data: Procedure
-) extends CfgNodeWithData[Procedure]:
-  override def block: Block = data.blocks.head
+class CfgFunctionEntryNode(val data: Procedure) extends CfgNodeWithData[Procedure]:
   override def toString: String = s"[FunctionEntry] $data"
 
   /** Copy this node, but give unique ID and reset edges */
-  override def copyNode(): CfgFunctionEntryNode = CfgFunctionEntryNode(data = this.data)
+  override def copyNode(): CfgFunctionEntryNode = CfgFunctionEntryNode(data)
 
 /** Control-flow graph node for the exit of a function.
   */
-case class CfgFunctionExitNode(
-    override val id: Int = CfgNode.nextId(),
-    override val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    data: Procedure
-) extends CfgNodeWithData[Procedure]:
-  override def block: Block = data.blocks.head
+class CfgFunctionExitNode(val data: Procedure) extends CfgNodeWithData[Procedure]:
   override def toString: String = s"[FunctionExit] $data"
 
   /** Copy this node, but give unique ID and reset edges */
-  override def copyNode(): CfgFunctionExitNode = CfgFunctionExitNode(data = this.data)
+  override def copyNode(): CfgFunctionExitNode = CfgFunctionExitNode(data)
 
 /** CFG node immediately proceeding a indirect call. This signifies that the call is a return from the current context
   * (i.e., likely an indirect call to R30). Its purpose is to provide a way for analyses to identify whether they should
@@ -244,13 +113,7 @@ case class CfgFunctionExitNode(
   * In the cfg we treat this as a stepping stone to `CfgFunctionExitNode`, as a way to emphasise that the current
   * procedure has no functionality past this point.
   */
-case class CfgProcedureReturnNode(
-    override val id: Int = CfgNode.nextId(),
-    override val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge]()
-) extends CfgNode:
+class CfgProcedureReturnNode() extends CfgNode:
   override def toString: String = s"[ProcedureReturn]"
 
   /** Copy this node, but give unique ID and reset edges */
@@ -268,13 +131,7 @@ case class CfgProcedureReturnNode(
   *
   * In the cfg this is similarly used as a stepping stone to `CfgFunctionExitNode`.
   */
-case class CfgCallNoReturnNode(
-    override val id: Int = CfgNode.nextId(),
-    override val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge]()
-) extends CfgNode:
+class CfgCallNoReturnNode() extends CfgNode:
   override def toString: String = s"[Call NoReturn]"
 
   /** Copy this node, but give unique ID and reset edges */
@@ -291,13 +148,7 @@ case class CfgCallNoReturnNode(
   * `Jmp` are then outgoing edges of the `CfgCallReturnNode`. It is functionally in the same spirit as
   * `CfgCallNoReturnNode`, though handles the case that this procedure still has functionality to be explored.
   */
-case class CfgCallReturnNode(
-    override val id: Int = CfgNode.nextId(),
-    override val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge]()
-) extends CfgNode:
+class CfgCallReturnNode() extends CfgNode:
   override def toString: String = s"[Call Return]"
 
   /** Copy this node, but give unique ID and reset edges */
@@ -313,96 +164,65 @@ trait CfgCommandNode extends CfgNodeWithData[Command] {
 
 /** CFG's representation of a single statement.
   */
-case class CfgStatementNode(
-    override val id: Int = CfgNode.nextId(),
-    override val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    data: Statement,
-    override val block: Block,
-    override val parent: CfgFunctionEntryNode
+class CfgStatementNode(
+    val data: Statement,
+    val block: Block,
+    val parent: CfgFunctionEntryNode
 ) extends CfgCommandNode:
   override def toString: String = s"[Stmt] $data"
 
   /** Copy this node, but give unique ID and reset edges */
-  override def copyNode(): CfgStatementNode = CfgStatementNode(data = this.data, block = this.block, parent = this.parent)
+  override def copyNode(): CfgStatementNode = CfgStatementNode(data, block, parent)
 
 /** CFG's representation of a jump. This is used as a general jump node, for both indirect and direct calls.
   */
-case class CfgJumpNode(
-    override val id: Int = CfgNode.nextId(),
-    override val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    data: Jump,
-    override val block: Block,
-    override val parent: CfgFunctionEntryNode
+class CfgJumpNode(
+    val data: Jump,
+    val block: Block,
+    val parent: CfgFunctionEntryNode
 ) extends CfgCommandNode:
   override def toString: String = s"[Jmp] $data"
 
   /** Copy this node, but give unique ID and reset edges */
-  override def copyNode(): CfgJumpNode = CfgJumpNode(data = this.data, block = this.block, parent = this.parent)
+  override def copyNode(): CfgJumpNode = CfgJumpNode(data, block, parent)
 
 /** A general purpose node which in terms of the IR has no functionality, but can have purpose in the CFG. As example,
   * this is used as a "block" start node for the case that a block contains no statements, but has a `GoTo` as its jump.
   * In this case we introduce a ghost node as the start of the block for the case that some part of the program jumps
   * back to this conditional jump (e.g. in the case of loops).
   */
-case class CfgGhostNode(
-    override val id: Int = CfgNode.nextId(),
-    override val predIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val predInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succIntra: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val succInter: mutable.Set[CfgEdge] = mutable.Set[CfgEdge](),
-    override val block: Block,
-    override val parent: CfgFunctionEntryNode,
-    override val data: NOP
+class CfgGhostNode(
+    val block: Block,
+    val parent: CfgFunctionEntryNode,
+    val data: NOP
 ) extends CfgCommandNode:
   override def toString: String = s"[NOP] $data"
 
   /** Copy this node, but give unique ID and reset edges */
-  override def copyNode(): CfgGhostNode = CfgGhostNode(block = this.block, parent = this.parent, data = this.data)
+  override def copyNode(): CfgGhostNode = CfgGhostNode(block, parent, data)
 
 /** A control-flow graph. Nodes provide the ability to walk it as both an intra and inter procedural CFG.
   */
 class ProgramCfg:
 
   var startNode: CfgFunctionEntryNode = _
-
-  var edges: mutable.Set[CfgEdge] = mutable.Set[CfgEdge]()
-  var nodes: mutable.Set[CfgNode] = mutable.Set[CfgNode]()
+  var nodes: mutable.Set[CfgNode] = mutable.Set()
 
   /** Inline edges are for connecting an intraprocedural cfg with a copy of another procedure's intraprocedural cfg
     * which is placed inside this one. They are considered interprocedural edges, and will not be followed if the caller
     * requests an intraprocedural cfg.
-    *
-    * @return
-    *   The new edge
     */
-  def addInlineEdge(from: CfgNode, to: CfgNode, cond: Expr = TrueLiteral): CfgEdge = {
-    val newEdge: InlineEdge = InlineEdge(from, to, cond)
-
-    from.succInter += newEdge
-    to.predInter += newEdge
-
-    newEdge
+  def addInlineEdge(from: CfgNode, to: CfgNode): Unit = {
+    from.succInter += to
+    to.predInter += from
   }
 
   /** Interprocedural call edges connect an intraprocedural cfg with another procedure's intraprocedural cfg that it is
     * calling.
-    *
-    * @return
-    *   The new edge
     */
-  def addInterprocCallEdge(from: CfgNode, to: CfgNode, cond: Expr = TrueLiteral): CfgEdge = {
-    val newEdge: InterprocCallEdge = InterprocCallEdge(from, to, cond)
-
-    from.succInter += newEdge
-    to.predInter += newEdge
-
-    newEdge
+  def addInterprocCallEdge(from: CfgNode, to: CfgNode, cond: Expr = TrueLiteral): Unit = {
+    from.succInter += to
+    to.predInter += from
   }
 
   /** Intraprocedural edges are for connecting call nodes to the call's return node, without following the call itself
@@ -411,29 +231,18 @@ class ProgramCfg:
     * @return
     *   The new edge
     */
-  def addIntraprocEdge(from: CfgNode, to: CfgNode, cond: Expr = TrueLiteral): CfgEdge = {
-    val newEdge: IntraprocEdge = IntraprocEdge(from, to, cond)
-
-    from.succIntra += newEdge
-    to.predIntra += newEdge
-
-    newEdge
+  def addIntraprocEdge(from: CfgNode, to: CfgNode, cond: Expr = TrueLiteral): Unit = {
+    from.succIntra += to
+    to.predIntra += from
   }
 
   /** Regular edges are normal control flow - used in both inter-/intra-procedural cfgs.
-    *
-    * @return
-    *   The new edge
     */
-  def addRegularEdge(from: CfgNode, to: CfgNode, cond: Expr = TrueLiteral): CfgEdge = {
-    val newEdge: RegularEdge = RegularEdge(from, to, cond)
-
-    from.succInter += newEdge
-    from.succIntra += newEdge
-    to.predInter += newEdge
-    to.predIntra += newEdge
-
-    newEdge
+  def addRegularEdge(from: CfgNode, to: CfgNode): Unit = {
+    from.succInter += to
+    from.succIntra += to
+    to.predInter += from
+    to.predIntra += from
   }
 
   /** Add an outgoing edge from the current node, taking into account any conditionals on this jump. Note that we have
@@ -449,44 +258,36 @@ class ProgramCfg:
     *   The originating node
     * @param to
     *   The destination node
-    * @param cond
-    *   Condition on this edge, otherwise assume it will always be followed
     */
-  def addEdge(from: CfgNode, to: CfgNode, cond: Expr = TrueLiteral): Unit = {
+  def addEdge(from: CfgNode, to: CfgNode): Unit = {
 
-    val newEdge: CfgEdge = (from, to) match {
+    (from, to) match {
       // Ignored procedure (e.g. library calls such as @printf)
-      case (from: CfgFunctionEntryNode, to: CfgFunctionExitNode) => addRegularEdge(from, to, TrueLiteral)
+      case (from: CfgFunctionEntryNode, to: CfgFunctionExitNode) => addRegularEdge(from, to)
       // Calling procedure (follow as inline)
       //  This to be used if inlining skips the call node and links the most recent statement to the first statement of the target
-      case (from: CfgCommandNode, to: CfgFunctionEntryNode) => addInlineEdge(from, to, cond)
+      case (from: CfgCommandNode, to: CfgFunctionEntryNode) => addInlineEdge(from, to)
       // Returning from procedure (follow as inline - see above)
-      case (from: CfgFunctionExitNode, to: CfgNode) => addInlineEdge(from, to, cond)
+      case (from: CfgFunctionExitNode, to: CfgNode) => addInlineEdge(from, to)
       // First instruction of procedure
-      case (from: CfgFunctionEntryNode, to: CfgNode) => addRegularEdge(from, to, cond)
+      case (from: CfgFunctionEntryNode, to: CfgNode) => addRegularEdge(from, to)
       // Function call which returns to the previous context
-      case (from: CfgJumpNode, to: CfgProcedureReturnNode) => addRegularEdge(from, to, cond)
+      case (from: CfgJumpNode, to: CfgProcedureReturnNode) => addRegularEdge(from, to)
       // Edge to intermediary return node (no semantic meaning, a cfg convenience edge)
-      case (from: CfgJumpNode, to: (CfgCallReturnNode | CfgCallNoReturnNode)) => addIntraprocEdge(from, to, cond)
+      case (from: CfgJumpNode, to: (CfgCallReturnNode | CfgCallNoReturnNode)) => addIntraprocEdge(from, to)
       // Pre-exit nodes
       case (from: (CfgProcedureReturnNode | CfgCallNoReturnNode | CfgCallReturnNode), to: CfgFunctionExitNode) =>
-        addRegularEdge(from, to, cond)
+        addRegularEdge(from, to)
       // Regular continuation of execution
-      case (from: CfgCallReturnNode, to: CfgCommandNode) => addRegularEdge(from, to, cond)
+      case (from: CfgCallReturnNode, to: CfgCommandNode) => addRegularEdge(from, to)
       // Regular flow of instructions
-      case (from: CfgCommandNode, to: (CfgCommandNode | CfgFunctionExitNode)) => addRegularEdge(from, to, cond)
+      case (from: CfgCommandNode, to: (CfgCommandNode | CfgFunctionExitNode)) => addRegularEdge(from, to)
       case _ => throw new Exception(s"[!] Unexpected edge combination when adding cfg edge between $from -> $to.")
     }
 
-    edges += newEdge
     nodes += from
     nodes += to
   }
-
-  /** Add a node to the CFG.
-    */
-  def addNode(node: CfgNode): Unit =
-    nodes += node
 
   /** Returns a Graphviz dot representation of the CFG. Each node is labeled using the given function labeler.
     */
@@ -500,53 +301,43 @@ class ProgramCfg:
     }
     nodes.foreach { n =>
 
-      val allEdgesOut: Set[CfgEdge] = n.succEdges(true).toSet.union(n.succEdges(false))
+      val successors = n.succIntra.toSet.union(n.succInter)
 
-      allEdgesOut.foreach { edge =>
-        val from: CfgNode = edge.getFrom
-        val to: CfgNode = edge.getTo
-        val cond: Expr = edge.getCond
+      successors.foreach { s =>
+        (n, s) match {
+          case (from: CfgFunctionEntryNode, to: CfgNode) =>
+            dotArrows += DotRegularArrow(dotNodes(n), dotNodes(to))
+          case (from: CfgJumpNode, to: CfgProcedureReturnNode) =>
+            dotArrows += DotRegularArrow(dotNodes(n), dotNodes(to))
+          case (from: (CfgProcedureReturnNode | CfgCallNoReturnNode | CfgCallReturnNode), to: CfgFunctionExitNode) =>
+            dotArrows += DotRegularArrow(dotNodes(n), dotNodes(to))
+          case (from: CfgCallReturnNode, to: CfgCommandNode) =>
+            dotArrows += DotRegularArrow(dotNodes(n), dotNodes(to))
+          case (from: CfgCommandNode, to: (CfgCommandNode | CfgFunctionExitNode)) =>
+            dotArrows += DotRegularArrow(dotNodes(n), dotNodes(to))
 
-        edge match {
-          case regular: RegularEdge =>
-            cond match {
-              case TrueLiteral =>
-                dotArrows += DotRegularArrow(dotNodes(n), dotNodes(to))
-              case _ =>
-                dotArrows += DotRegularArrow(dotNodes(n), dotNodes(to), cond.toString)
-            }
-          case intra: IntraprocEdge =>
-            cond match {
-              case TrueLiteral =>
-                dotArrows += DotIntraArrow(dotNodes(n), dotNodes(to))
-              case _ =>
-                dotArrows += DotIntraArrow(dotNodes(n), dotNodes(to), cond.toString)
-            }
-          case inline: InlineEdge =>
-            cond match {
-              case TrueLiteral =>
-                dotArrows += DotInlineArrow(dotNodes(n), dotNodes(to))
-              case _ =>
-                dotArrows += DotInlineArrow(dotNodes(n), dotNodes(to), cond.toString)
-            }
-          /* Displaying the below in the CFG is mostly for debugging purposes. With it included the CFG becomes a little unreadable, but
-                will emphasise that the leaf-call nodes are linked to the start of the procedures they're calling (as green inter-procedural edges).
-                To verify this is still happening, simply uncomment the below and it will add these edges.
-           */
-          // case interCall: InterprocCallEdge =>
-          //   cond match {
-          //     case TrueLiteral =>
-          //       dotArrows += DotInterArrow(dotNodes(n), dotNodes(to))
-          //     case _ =>
-          //       dotArrows += DotInterArrow(dotNodes(n), dotNodes(to), cond.toString())
-          //   }
+          case (from: CfgCommandNode, to: CfgFunctionEntryNode) =>
+            DotInlineArrow(dotNodes(n), dotNodes(to))
+
+          case (from: CfgFunctionExitNode, to: CfgNode) =>
+            DotInlineArrow(dotNodes(n), dotNodes(to))
+
+          case (from: CfgJumpNode, to: (CfgCallReturnNode | CfgCallNoReturnNode)) =>
+            dotArrows += DotIntraArrow(dotNodes(n), dotNodes(to))
+          /*
+          Displaying the below in the CFG is mostly for debugging purposes. With it included the CFG becomes a little unreadable, but
+          will emphasise that the leaf-call nodes are linked to the start of the procedures they're calling (as green inter-procedural edges).
+          To verify this is still happening, simply uncomment the below and it will add these edges.
+          case (from: CfgCommandNode, to: CfgFunctionEntry) =>
+            dotArrows += DotInterArrow(dotNodes(n), dotNodes(to))
+            */
           case _ =>
         }
       }
     }
     dotArrows = dotArrows.sortBy(arr => arr.fromNode.id + "-" + arr.toNode.id)
     val allNodes = dotNodes.values.toList.sortBy(n => n.id)
-    new DotGraph("CFG", allNodes, dotArrows).toDotString
+    DotGraph("CFG", allNodes, dotArrows).toDotString
   }
 
   override def toString: String = {
@@ -554,8 +345,6 @@ class ProgramCfg:
     sb.append("CFG {")
     sb.append(" nodes: ")
     sb.append(nodes)
-    sb.append(" edges: ")
-    sb.append(edges)
     sb.append("}")
     sb.toString()
   }
@@ -633,10 +422,10 @@ class ProgramCfgFactory:
     *   Procedure for which to generate the intraprocedural cfg
     */
   private def cfgForProcedure(proc: Procedure): Unit = {
-    val funcEntryNode: CfgFunctionEntryNode = CfgFunctionEntryNode(data = proc)
-    val funcExitNode: CfgFunctionExitNode = CfgFunctionExitNode(data = proc)
-    cfg.addNode(funcEntryNode)
-    cfg.addNode(funcExitNode)
+    val funcEntryNode: CfgFunctionEntryNode = CfgFunctionEntryNode(proc)
+    val funcExitNode: CfgFunctionExitNode = CfgFunctionExitNode(proc)
+    cfg.nodes += funcEntryNode
+    cfg.nodes += funcEntryNode
 
     procToCfg += (proc -> (funcEntryNode, funcExitNode))
     callToNodes += (funcEntryNode -> mutable.Set[CfgCommandNode]())
@@ -708,8 +497,8 @@ class ProgramCfgFactory:
         */
       def visitStmts(stmts: ArrayBuffer[Statement], prevNode: CfgNode, cond: Expr): CfgCommandNode = {
 
-        val firstNode: CfgStatementNode = CfgStatementNode(data = stmts.head, block = block, parent = funcEntryNode)
-        cfg.addEdge(prevNode, firstNode, cond)
+        val firstNode: CfgStatementNode = CfgStatementNode(stmts.head, block, funcEntryNode)
+        cfg.addEdge(prevNode, firstNode)
         visitedBlocks += (block -> firstNode) // This is guaranteed to be entrance to block if we are here
 
         if (stmts.size == 1) {
@@ -721,7 +510,7 @@ class ProgramCfgFactory:
 
         // `tail` takes everything after the first element of the iterable
         stmts.tail.foreach(stmt =>
-          val stmtNode: CfgStatementNode = CfgStatementNode(data = stmt, block = block, parent = funcEntryNode)
+          val stmtNode: CfgStatementNode = CfgStatementNode(stmt, block, funcEntryNode)
           cfg.addEdge(prevStmtNode, stmtNode)
           prevStmtNode = stmtNode
         )
@@ -745,7 +534,7 @@ class ProgramCfgFactory:
         */
       def visitJump(jmp: Jump, prevNode: CfgNode, cond: Expr, solitary: Boolean): Unit = {
 
-        val jmpNode: CfgJumpNode = CfgJumpNode(data = jmp, block = block, parent = funcEntryNode)
+        val jmpNode: CfgJumpNode = CfgJumpNode(jmp, block, funcEntryNode)
         var precNode: CfgNode = prevNode
 
         if (solitary) {
@@ -760,8 +549,8 @@ class ProgramCfgFactory:
           jmp match {
             case jmp: GoTo =>
               // `GoTo`s are just edges, so introduce a fake `start of block` that can be jmp'd to
-              val ghostNode = CfgGhostNode(block = block, parent = funcEntryNode, data = NOP(jmp.label))
-              cfg.addEdge(prevNode, ghostNode, cond)
+              val ghostNode = CfgGhostNode(block, funcEntryNode, NOP(jmp.label))
+              cfg.addEdge(prevNode, ghostNode)
               precNode = ghostNode
               visitedBlocks += (block -> ghostNode)
             case _ =>
@@ -785,7 +574,7 @@ class ProgramCfgFactory:
           case dCall: DirectCall =>
             val targetProc: Procedure = dCall.target
 
-            val callNode = CfgJumpNode(data = dCall, block = block, parent = funcEntryNode)
+            val callNode = CfgJumpNode(dCall, block, funcEntryNode)
 
             // Branch to this call
             cfg.addEdge(precNode, callNode)
@@ -818,7 +607,7 @@ class ProgramCfgFactory:
             Logger.info(s"Indirect call found: $iCall in ${proc.name}")
 
             // Branch to this call
-            cfg.addEdge(precNode, jmpNode, cond)
+            cfg.addEdge(precNode, jmpNode)
 
             // Record call association
             procToCalls(proc) += jmpNode
@@ -918,6 +707,7 @@ class ProgramCfgFactory:
     * @return
     *   Tthe next leaf call nodes
     */
+  @tailrec
   private def inlineProcedureCalls(procNodes: Set[CfgCommandNode], inlineAmount: Int): Set[CfgCommandNode] = {
     assert(inlineAmount >= 0)
     Logger.info(s"[+] Inlining ${procNodes.size} leaf call nodes with $inlineAmount level(s) left")
@@ -941,10 +731,10 @@ class ProgramCfgFactory:
 
           // Link the procedure's `Exit` to the return point. There should only be one.
           assert(
-            procNode.succ(intra = true).size == 1,
-            s"More than 1 return node... $procNode has ${procNode.succ(intra = true)}"
+            procNode.succIntra.size == 1,
+            s"More than 1 return node... $procNode has ${procNode.succIntra}"
           )
-          val returnNode = procNode.succ(intra = true).head
+          val returnNode = procNode.succIntra.head
           cfg.addInlineEdge(procExit, returnNode)
 
           // Add new (un-inlined) function calls to be inlined
@@ -956,6 +746,7 @@ class ProgramCfgFactory:
     inlineProcedureCalls(nextProcNodes.toSet, inlineAmount - 1)
   }
 
+  @tailrec
   private def unifyProcedureCalls(procNodes: Set[CfgCommandNode]): Set[CfgCommandNode] = {
     Logger.info(s"[+] Unifyig ${procNodes.size} leaf call nodest")
 
@@ -978,10 +769,10 @@ class ProgramCfgFactory:
 
           // Link the procedure's `Exit` to the return point. There should only be one.
           assert(
-            procNode.succ(intra = true).size == 1,
-            s"More than 1 return node... $procNode has ${procNode.succ(intra = true)}"
+            procNode.succIntra.size == 1,
+            s"More than 1 return node... $procNode has ${procNode.succIntra}"
           )
-          val returnNode = procNode.succ(intra = true).head
+          val returnNode = procNode.succIntra.head
           cfg.addInlineEdge(procExit, returnNode)
 
           // Add new (un-inlined) function calls to be inlined
@@ -1009,8 +800,8 @@ class ProgramCfgFactory:
     callToNodes += (newEntry -> mutable.Set[CfgCommandNode]())
 
     // Entry is guaranteed to only have one successor (by our cfg design)
-    val currNode: CfgNode = entryNode.succ(intra = true).head
-    visitNode(currNode, newEntry, TrueLiteral)
+    val currNode: CfgNode = entryNode.succIntra.head
+    visitNode(currNode, newEntry)
 
     /** Walk this proc's cfg until we reach the exit node on each branch. We do this recursively, tracking the previous
       * node, to account for branches and loops.
@@ -1024,10 +815,10 @@ class ProgramCfgFactory:
       * @param cond
       *   The condition leading to `node` from `prevNewNode`
       */
-    def visitNode(node: CfgNode, prevNewNode: CfgNode, cond: Expr): Unit = {
+    def visitNode(node: CfgNode, prevNewNode: CfgNode): Unit = {
 
       if (node == exitNode) {
-        cfg.addEdge(prevNewNode, newExit, cond)
+        cfg.addEdge(prevNewNode, newExit)
         return
       }
 
@@ -1036,7 +827,7 @@ class ProgramCfgFactory:
           val newNode: CfgCommandNode = n.copyNode()
 
           // Link this node with predecessor in the new cfg
-          cfg.addEdge(prevNewNode, newNode, cond)
+          cfg.addEdge(prevNewNode, newNode)
 
           n.data match {
             case d: DirectCall =>
@@ -1050,16 +841,16 @@ class ProgramCfgFactory:
           }
 
           // Get intra-cfg successors
-          val outEdges: mutable.Set[CfgEdge] = node.succEdges(intra = true)
-          outEdges.foreach(edge => visitNode(edge.getTo, newNode, edge.getCond))
+          val outNodes = node.succIntra
+          outNodes.foreach(node => visitNode(node, newNode))
 
         // For other node types, link with predecessor and continue traversal
         case _ =>
           val newNode = node.copyNode()
-          cfg.addEdge(prevNewNode, newNode, cond)
+          cfg.addEdge(prevNewNode, newNode)
 
-          val outEdges: mutable.Set[CfgEdge] = node.succEdges(intra = true)
-          outEdges.foreach(edge => visitNode(edge.getTo, newNode, edge.getCond))
+          val outNodes = node.succIntra
+          outNodes.foreach(node => visitNode(node, newNode))
       }
     }
 

--- a/src/main/scala/analysis/Cfg.scala
+++ b/src/main/scala/analysis/Cfg.scala
@@ -6,7 +6,6 @@ import cfg_visualiser.{DotArrow, DotGraph, DotInlineArrow, DotInterArrow, DotInt
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.util.control.Breaks.break
-import analysis.Fresh.next
 import util.Logger
 
 /** Node in the control-flow graph.

--- a/src/main/scala/analysis/Cfg.scala
+++ b/src/main/scala/analysis/Cfg.scala
@@ -365,10 +365,9 @@ class ProgramCfgFactory:
     * @param program
     *   Basil IR of the program
     * @param inlineLimit
-    *   How many levels deep to inline function calls. By default, don't inline - this is equivalent to an
-    *   intra-procedural CFG.
+    *   How many levels deep to inline function calls. Default is 3
     */
-  def fromIR(program: Program, unify: Boolean = false, inlineLimit: Int = 0): ProgramCfg = {
+  def fromIR(program: Program, unify: Boolean = false, inlineLimit: Int = 3): ProgramCfg = {
     CfgNode.id = 0
     require(inlineLimit >= 0, "Can't inline procedures to negative depth...")
     Logger.info("[+] Generating CFG...")

--- a/src/main/scala/analysis/Dependencies.scala
+++ b/src/main/scala/analysis/Dependencies.scala
@@ -21,11 +21,11 @@ trait Dependencies[N]:
   def indep(n: N): Set[N]
 
 trait InterproceduralForwardDependencies extends Dependencies[CfgNode] {
-  def outdep(n: CfgNode): Set[CfgNode] = n.succ(false).toSet.union(n.succ(true).toSet)
-  def indep(n: CfgNode): Set[CfgNode] = n.pred(false).toSet.union(n.pred(true).toSet)
+  def outdep(n: CfgNode): Set[CfgNode] = n.succInter.toSet.union(n.succIntra.toSet)
+  def indep(n: CfgNode): Set[CfgNode] = n.predInter.toSet.union(n.predIntra.toSet)
 }
 
 trait IntraproceduralForwardDependencies extends Dependencies[CfgNode] {
-  def outdep(n: CfgNode): Set[CfgNode] = n.succ(true).toSet
-  def indep(n: CfgNode): Set[CfgNode] = n.pred(true).toSet
+  def outdep(n: CfgNode): Set[CfgNode] = n.succIntra.toSet
+  def indep(n: CfgNode): Set[CfgNode] = n.predIntra.toSet
 }

--- a/src/main/scala/analysis/Dependencies.scala
+++ b/src/main/scala/analysis/Dependencies.scala
@@ -21,8 +21,8 @@ trait Dependencies[N]:
   def indep(n: N): Set[N]
 
 trait InterproceduralForwardDependencies extends Dependencies[CfgNode] {
-  def outdep(n: CfgNode): Set[CfgNode] = n.succInter.toSet.union(n.succIntra.toSet)
-  def indep(n: CfgNode): Set[CfgNode] = n.predInter.toSet.union(n.predIntra.toSet)
+  def outdep(n: CfgNode): Set[CfgNode] = n.succInter.toSet
+  def indep(n: CfgNode): Set[CfgNode] = n.predInter.toSet
 }
 
 trait IntraproceduralForwardDependencies extends Dependencies[CfgNode] {

--- a/src/main/scala/analysis/Dependencies.scala
+++ b/src/main/scala/analysis/Dependencies.scala
@@ -10,7 +10,7 @@ trait Dependencies[N]:
     * @return
     *   the elements that depend on the given element
     */
-  def outdep(n: N, intra: Boolean): Set[N]
+  def outdep(n: N): Set[N]
 
   /** Incoming dependencies. Used when computing the join from predecessors.
     * @param n
@@ -18,17 +18,14 @@ trait Dependencies[N]:
     * @return
     *   the elements that the given element depends on
     */
-  def indep(n: N, intra: Boolean): Set[N]
+  def indep(n: N): Set[N]
 
-/** Dependency methods for forward analyses.
-  */
-trait ForwardDependencies extends Dependencies[CfgNode]:
+trait InterproceduralForwardDependencies extends Dependencies[CfgNode] {
+  def outdep(n: CfgNode): Set[CfgNode] = n.succ(false).toSet.union(n.succ(true).toSet)
+  def indep(n: CfgNode): Set[CfgNode] = n.pred(false).toSet.union(n.pred(true).toSet)
+}
 
-  /* TODO: add functionality here for distinguishing between Intra / Inter */
-
-  // Also add support for getting edges / conditions here?
-  def outdep(n: CfgNode, intra: Boolean = true): Set[CfgNode] =
-    if intra then n.succ(intra).toSet else n.succ(intra).toSet.union(n.succ(!intra).toSet)
-
-  def indep(n: CfgNode, intra: Boolean = true): Set[CfgNode] =
-    if intra then n.pred(intra).toSet else n.pred(intra).toSet.union(n.pred(!intra).toSet)
+trait IntraproceduralForwardDependencies extends Dependencies[CfgNode] {
+  def outdep(n: CfgNode): Set[CfgNode] = n.succ(true).toSet
+  def indep(n: CfgNode): Set[CfgNode] = n.pred(true).toSet
+}

--- a/src/main/scala/analysis/Lattice.scala
+++ b/src/main/scala/analysis/Lattice.scala
@@ -6,11 +6,11 @@ import util.Logger
 
 /** Basic lattice
   */
-trait Lattice:
+trait Lattice[T]:
 
   /** The type of the elements of this lattice.
     */
-  type Element
+  type Element = T
 
   /** The bottom element of this lattice.
     */
@@ -28,210 +28,91 @@ trait Lattice:
     */
   def leq(x: Element, y: Element): Boolean = lub(x, y) == y // rarely used, but easy to implement :-)
 
-/** Lattice with abstract operators.
-  */
-trait LatticeWithOps extends Lattice:
-
-  def literal(l: Literal): Element
-  def bvadd(a: Element, b: Element): Element
-  def bvsub(a: Element, b: Element): Element
-  def bvmul(a: Element, b: Element): Element
-  def bvudiv(a: Element, b: Element): Element
-  def bvsdiv(a: Element, b: Element): Element
-  def bvsrem(a: Element, b: Element): Element
-  def bvurem(a: Element, b: Element): Element
-  def bvsmod(a: Element, b: Element): Element
-  def bvshl(a: Element, b: Element): Element
-  def bvlshr(a: Element, b: Element): Element
-  def bvashr(a: Element, b: Element): Element
-  def bvand(a: Element, b: Element): Element
-  def bvor(a: Element, b: Element): Element
-  def bvxor(a: Element, b: Element): Element
-  def bvnand(a: Element, b: Element): Element
-  def bvnor(a: Element, b: Element): Element
-  def bvxnor(a: Element, b: Element): Element
-  def bvule(a: Element, b: Element): Element
-  def bvuge(a: Element, b: Element): Element
-  def bvult(a: Element, b: Element): Element
-  def bvugt(a: Element, b: Element): Element
-  def bvsle(a: Element, b: Element): Element
-  def bvsge(a: Element, b: Element): Element
-  def bvslt(a: Element, b: Element): Element
-  def bvsgt(a: Element, b: Element): Element
-  def bvcomp(a: Element, b: Element): Element
-  def zero_extend(width: Int, a: Element): Element
-  def sign_extend(width: Int, a: Element): Element
-  def extract(high: Int, low: Int, a: Element): Element
-  def bvnot(a: Element): Element
-  def bvneg(a: Element): Element
-  def bvneq(a: Element, b: Element): Element
-  def bveq(a: Element, b: Element): Element
-  def concat(a: Element, b: Element): Element
-
 /** The powerset lattice of a set of elements of type `A` with subset ordering.
   */
-class PowersetLattice[A] extends Lattice {
-
-  type Element = Set[A]
-
+class PowersetLattice[A] extends Lattice[Set[A]] {
   val bottom: Element = Set.empty
-
   def lub(x: Element, y: Element): Element = x.union(y)
 }
+
+trait FlatElement[+T]
+case class FlatEl[T](el: T) extends FlatElement[T]
+case object Top extends FlatElement[Nothing]
+case object Bottom extends FlatElement[Nothing]
 
 /** The flat lattice made of element of `X`. Top is greater than every other element, and Bottom is less than every
   * other element. No additional ordering is defined.
   */
-class FlatLattice[X] extends Lattice:
+class FlatLattice[X] extends Lattice[FlatElement[X]] {
 
-  sealed trait FlatElement
+  val bottom: FlatElement[X] = Bottom
 
-  object FlatElement:
-    case class FlatEl(el: X) extends FlatElement
+  override val top: FlatElement[X] = Top
 
-    case object Top extends FlatElement
+  def lub(x: Element, y: Element): Element = (x, y) match {
+    case (a, Bottom) => a
+    case (Bottom, b) => b
+    case (a, b) if a == b => a
+    case (Top, _) => Top
+    case (_, Top) => Top
+    case _ => Top
+  }
+}
 
-    case object Bot extends FlatElement
-
-    // Factory method to create FlatEl
-    def apply(x: X): FlatEl = FlatEl(x)
-
-    // Extraction/unapply method for pattern matching
-    def unapply(arg: FlatEl): Option[X] = Some(arg.el)
-
-  type Element = FlatElement
-
-
-  val bottom: Element = FlatElement.Bot
-
-  override val top: Element = FlatElement.Top
-
-  def lub(x: Element, y: Element): Element =
-    if x == FlatElement.Bot || y == FlatElement.Top || x == y then y
-    else if y == FlatElement.Bot || x == FlatElement.Top then x
-    else FlatElement.Top
-
-/** A lattice of maps from a set of elements of type `A` to the lattice `sublattice`. Bottom is the default value.
+/** A lattice of maps from a set of elements of type `A` to a lattice with element `L'. Bottom is the default value.
   */
-class MapLattice[A, +L <: Lattice](val sublattice: L) extends Lattice:
-
-  type Element = Map[A, sublattice.Element]
-
-  val bottom: Element = Map().withDefaultValue(sublattice.bottom)
-
+class MapLattice[A, T, +L <: Lattice[T]](val sublattice: L) extends Lattice[Map[A, T]] {
+  val bottom: Map[A, T] = Map().withDefaultValue(sublattice.bottom)
   def lub(x: Element, y: Element): Element =
     x.keys.foldLeft(y)((m, a) => m + (a -> sublattice.lub(x(a), y(a)))).withDefaultValue(sublattice.bottom)
+}
 
 /** Constant propagation lattice.
+  *
   */
-object ConstantPropagationLattice extends FlatLattice[Literal]() with LatticeWithOps:
-
-  private def apply(op: (Literal, Literal) => Literal, a: Element, b: Element): Element = try {
+class ConstantPropagationLattice extends FlatLattice[BitVecLiteral] {
+  private def apply(op: (BitVecLiteral, BitVecLiteral) => BitVecLiteral, a: Element, b: Element): Element = try {
     (a, b) match
-      case (FlatElement.FlatEl(x), FlatElement.FlatEl(y)) =>
-        FlatElement.FlatEl(op(x, y))
-      case (FlatElement.Bot, _) => FlatElement.Bot
-      case (_, FlatElement.Bot) => FlatElement.Bot
-      case (_, FlatElement.Top) => FlatElement.Top
-      case (FlatElement.Top, _) => FlatElement.Top
+      case (FlatEl(x), FlatEl(y)) => FlatEl(op(x, y))
+      case (Bottom, _) => Bottom
+      case (_, Bottom) => Bottom
+      case (_, Top) => Top
+      case (Top, _) => Top
   } catch {
     case e: Exception =>
       Logger.error(s"Failed on op $op with $a and $b")
       throw e
   }
 
-  private def apply(op: Literal => Literal, a: Element): Element = a match
-    case FlatElement.FlatEl(x) => FlatElement.FlatEl(op(x))
-    case FlatElement.Top       => FlatElement.Top
-    case FlatElement.Bot       => FlatElement.Bot
+  private def apply(op: BitVecLiteral => BitVecLiteral, a: Element): Element = a match
+    case FlatEl(x) => FlatEl(op(x))
+    case Top => Top
+    case Bottom => Bottom
 
-  override def literal(l: Literal): Element = FlatElement.FlatEl(l)
-  override def bvadd(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvadd, a, b)
-  override def bvsub(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsub, a, b)
-  override def bvmul(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvmul, a, b)
-  override def bvudiv(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvudiv, a, b)
-  override def bvsdiv(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsdiv, a, b)
-  override def bvsrem(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsrem, a, b)
-  override def bvurem(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvurem, a, b)
-  override def bvsmod(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsmod, a, b)
-  override def bvand(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvand, a, b)
-  override def bvor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvor, a, b)
-  override def bvxor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvxor, a, b)
-  override def bvnand(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvnand, a, b)
-  override def bvnor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvnor, a, b)
-  override def bvxnor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvxnor, a, b)
-  override def bvnot(a: Element): Element = apply(BitVectorEval.smt_bvnot, a)
-  override def bvneg(a: Element): Element = apply(BitVectorEval.smt_bvneg, a)
-  override def bvshl(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvshl, a, b)
-  override def bvlshr(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvlshr, a, b)
-  override def bvashr(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvashr, a, b)
-  override def bvcomp(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvcomp, a, b)
-  override def bvule(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvule, a, b)
-  override def bvuge(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvuge, a, b)
-  override def bvult(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvult, a, b)
-  override def bvugt(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvugt, a, b)
-  override def bvsle(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsle, a, b)
-  override def bvsge(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsge, a, b)
-  override def bvslt(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvslt, a, b)
-  override def bvsgt(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsgt, a, b)
-  override def zero_extend(width: Int, a: Element): Element = apply(BitVectorEval.smt_zero_extend(width, _: Literal), a)
-  override def sign_extend(width: Int, a: Element): Element = apply(BitVectorEval.smt_sign_extend(width, _: Literal), a)
-  override def extract(high: Int, low: Int, a: Element): Element =
-    apply(BitVectorEval.boogie_extract(high, low, _: Literal), a)
-  override def concat(a: Element, b: Element): Element = apply(BitVectorEval.smt_concat, a, b)
-  override def bvneq(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvneq, a, b)
-  override def bveq(a: Element, b: Element): Element = apply(BitVectorEval.smt_bveq, a, b)
-
-// value-set lattice
-/** Constant propagation lattice.
-  */
-object ValueSetLattice extends FlatLattice[Literal]() with LatticeWithOps:
-
-  private def apply(op: (Literal, Literal) => Literal, a: Element, b: Element): Element = (a, b) match
-    case (FlatElement.FlatEl(x), FlatElement.FlatEl(y)) => FlatElement.FlatEl(op(x, y))
-    case (FlatElement.Bot, _)                           => FlatElement.Bot
-    case (_, FlatElement.Bot)                           => FlatElement.Bot
-    case (_, FlatElement.Top)                           => FlatElement.Top
-    case (FlatElement.Top, _)                           => FlatElement.Top
-
-  private def apply(op: Literal => Literal, a: Element): Element = a match
-    case FlatElement.FlatEl(x) => FlatElement.FlatEl(op(x))
-    case FlatElement.Top       => FlatElement.Top
-    case FlatElement.Bot       => FlatElement.Bot
-
-  override def literal(l: Literal): Element = FlatElement.FlatEl(l)
-  override def bvadd(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvadd, a, b)
-  override def bvsub(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsub, a, b)
-  override def bvmul(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvmul, a, b)
-  override def bvudiv(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvudiv, a, b)
-  override def bvsdiv(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsdiv, a, b)
-  override def bvsrem(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsrem, a, b)
-  override def bvsmod(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsmod, a, b)
-  override def bvurem(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvurem, a, b)
-  override def bvand(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvand, a, b)
-  override def bvor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvor, a, b)
-  override def bvnand(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvnand, a, b)
-  override def bvnor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvnor, a, b)
-  override def bvxnor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvxnor, a, b)
-  override def bvxor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvxor, a, b)
-  override def bvnot(a: Element): Element = apply(BitVectorEval.smt_bvnot, a)
-  override def bvneg(a: Element): Element = apply(BitVectorEval.smt_bvneg, a)
-  override def bvshl(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvshl, a, b)
-  override def bvlshr(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvlshr, a, b)
-  override def bvashr(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvashr, a, b)
-  override def bvcomp(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvcomp, a, b)
-  override def bvule(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvule, a, b)
-  override def bvuge(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvuge, a, b)
-  override def bvult(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvult, a, b)
-  override def bvugt(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvugt, a, b)
-  override def bvsle(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsle, a, b)
-  override def bvsge(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsge, a, b)
-  override def bvslt(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvslt, a, b)
-  override def bvsgt(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsgt, a, b)
-  override def zero_extend(width: Int, a: Element): Element = apply(BitVectorEval.smt_zero_extend(width, _: Literal), a)
-  override def sign_extend(width: Int, a: Element): Element = apply(BitVectorEval.smt_sign_extend(width, _: Literal), a)
-  override def extract(high: Int, low: Int, a: Element): Element =
-    apply(BitVectorEval.boogie_extract(high, low, _: Literal), a)
-  override def concat(a: Element, b: Element): Element = apply(BitVectorEval.smt_concat, a, b)
-  override def bvneq(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvneq, a, b)
-  override def bveq(a: Element, b: Element): Element = apply(BitVectorEval.smt_bveq, a, b)
+  def bv(a: BitVecLiteral): Element = FlatEl(a)
+  def bvadd(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvadd, a, b)
+  def bvsub(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsub, a, b)
+  def bvmul(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvmul, a, b)
+  def bvudiv(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvudiv, a, b)
+  def bvsdiv(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsdiv, a, b)
+  def bvsrem(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsrem, a, b)
+  def bvurem(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvurem, a, b)
+  def bvsmod(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvsmod, a, b)
+  def bvand(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvand, a, b)
+  def bvor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvor, a, b)
+  def bvxor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvxor, a, b)
+  def bvnand(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvnand, a, b)
+  def bvnor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvnor, a, b)
+  def bvxnor(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvxnor, a, b)
+  def bvnot(a: Element): Element = apply(BitVectorEval.smt_bvnot, a)
+  def bvneg(a: Element): Element = apply(BitVectorEval.smt_bvneg, a)
+  def bvshl(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvshl, a, b)
+  def bvlshr(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvlshr, a, b)
+  def bvashr(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvashr, a, b)
+  def bvcomp(a: Element, b: Element): Element = apply(BitVectorEval.smt_bvcomp, a, b)
+  def zero_extend(width: Int, a: Element): Element = apply(BitVectorEval.smt_zero_extend(width, _: BitVecLiteral), a)
+  def sign_extend(width: Int, a: Element): Element = apply(BitVectorEval.smt_sign_extend(width, _: BitVecLiteral), a)
+  def extract(high: Int, low: Int, a: Element): Element =
+    apply(BitVectorEval.boogie_extract(high, low, _: BitVecLiteral), a)
+  def concat(a: Element, b: Element): Element = apply(BitVectorEval.smt_concat, a, b)
+}

--- a/src/main/scala/analysis/MemoryModelMap.scala
+++ b/src/main/scala/analysis/MemoryModelMap.scala
@@ -108,3 +108,36 @@ class MemoryModelMap {
     s"Stack: ${rangeMap.stackMap}\n Heap: ${rangeMap.heapMap}\n Data: ${rangeMap.dataMap}\n"
 
 }
+
+trait MemoryRegion {
+  val regionIdentifier: String
+  var extent: Option[RangeKey] = None
+}
+
+class StackRegion(override val regionIdentifier: String, val start: BitVecLiteral) extends MemoryRegion {
+  override def toString: String = s"Stack($regionIdentifier, $start)"
+  override def hashCode(): Int = regionIdentifier.hashCode() * start.hashCode()
+  override def equals(obj: Any): Boolean = obj match {
+    case s: StackRegion => s.start == start && s.regionIdentifier == regionIdentifier
+    case _ => false
+  }
+}
+
+class HeapRegion(override val regionIdentifier: String) extends MemoryRegion {
+  override def toString: String = s"Heap($regionIdentifier)"
+  override def hashCode(): Int = regionIdentifier.hashCode()
+  override def equals(obj: Any): Boolean = obj match {
+    case h: HeapRegion => h.regionIdentifier == regionIdentifier
+    case _ => false
+  }
+}
+
+class DataRegion(override val regionIdentifier: String, val start: BitVecLiteral) extends MemoryRegion {
+  override def toString: String = s"Data($regionIdentifier, $start)"
+  override def hashCode(): Int = regionIdentifier.hashCode() * start.hashCode()
+  override def equals(obj: Any): Boolean = obj match {
+    case d: DataRegion => d.start == start && d.regionIdentifier == regionIdentifier
+    case _ => false
+  }
+}
+

--- a/src/main/scala/analysis/SteensgaardAnalysis.scala
+++ b/src/main/scala/analysis/SteensgaardAnalysis.scala
@@ -1,7 +1,7 @@
 package analysis
 
 import analysis.solvers.{Cons, Term, UnionFindSolver, Var}
-import ir.{Block, DirectCall, Expr, LocalAssign, MemoryAssign, Procedure, Program, Variable}
+import ir.{Block, DirectCall, Expr, LocalAssign, MemoryAssign, Procedure, Program, Variable, BitVecLiteral}
 import util.Logger
 
 import java.io.{File, PrintWriter}
@@ -10,7 +10,7 @@ import scala.collection.mutable.ArrayBuffer
 /** Steensgaard-style pointer analysis. The analysis associates an [[StTerm]] with each variable declaration and
   * expression node in the AST. It is implemented using [[tip.solvers.UnionFindSolver]].
   */
-class SteensgaardAnalysis(program: Program, constantPropResult: Map[CfgNode, Map[Variable, ConstantPropagationLattice.Element]]) extends Analysis[Any] {
+class SteensgaardAnalysis(program: Program, constantPropResult: Map[CfgNode, Map[Variable, FlatElement[BitVecLiteral]]]) extends Analysis[Any] {
 
   val solver: UnionFindSolver[StTerm] = UnionFindSolver()
 
@@ -18,7 +18,7 @@ class SteensgaardAnalysis(program: Program, constantPropResult: Map[CfgNode, Map
 
   var mallocCallTarget: Option[Block] = None
 
-  val constantPropResult2: Map[CfgNode, Map[Variable, ConstantPropagationLattice.Element]] = constantPropResult
+  val constantPropResult2: Map[CfgNode, Map[Variable, FlatElement[BitVecLiteral]]] = constantPropResult
 
   constantPropResult2.values.foreach(v => Logger.info(s"$v"))
 

--- a/src/main/scala/analysis/SteensgaardAnalysis.scala
+++ b/src/main/scala/analysis/SteensgaardAnalysis.scala
@@ -24,7 +24,7 @@ class SteensgaardAnalysis(program: Program, constantPropResult: Map[CfgNode, Map
 
   /** @inheritdoc
     */
-  def analyze(intra: Boolean): Unit =
+  def analyze(): Unit =
   // generate the constraints by traversing the AST and solve them on-the-fly
     visit(program, ())
 

--- a/src/main/scala/analysis/SteensgaardAnalysis.scala
+++ b/src/main/scala/analysis/SteensgaardAnalysis.scala
@@ -219,3 +219,15 @@ case class PointerRef(of: Term[StTerm]) extends StTerm with Cons[StTerm] {
 
   override def toString: String = s"$of"
 }
+
+/** Counter for producing fresh IDs.
+  */
+object Fresh {
+
+  var n = 0
+
+  def next(): Int = {
+    n += 1
+    n
+  }
+}

--- a/src/main/scala/analysis/UtilMethods.scala
+++ b/src/main/scala/analysis/UtilMethods.scala
@@ -11,7 +11,7 @@ import util.Logger
   * @return:
   *   The evaluated expression (e.g. 0x69632)
   */
-def evaluateExpression(exp: Expr, constantPropResult: Map[Variable, ConstantPropagationLattice.FlatElement]): Option[BitVecLiteral] = {
+def evaluateExpression(exp: Expr, constantPropResult: Map[Variable, FlatElement[BitVecLiteral]]): Option[BitVecLiteral] = {
   Logger.debug(s"evaluateExpression: $exp")
   exp match {
     case binOp: BinaryExpr =>
@@ -41,9 +41,9 @@ def evaluateExpression(exp: Expr, constantPropResult: Map[Variable, ConstantProp
       }
     case variable: Variable =>
       constantPropResult(variable) match {
-        case ConstantPropagationLattice.FlatElement.FlatEl(value) => Some(value.asInstanceOf[BitVecLiteral])
-        case ConstantPropagationLattice.FlatElement.Top           => None
-        case ConstantPropagationLattice.FlatElement.Bot           => None
+        case FlatEl(value) => Some(value)
+        case Top           => None
+        case Bottom           => None
       }
     case b: BitVecLiteral => Some(b)
     case _ => //throw new RuntimeException("ERROR: CASE NOT HANDLED: " + exp + "\n")

--- a/src/main/scala/analysis/VSA.scala
+++ b/src/main/scala/analysis/VSA.scala
@@ -41,7 +41,7 @@ trait ValueSetAnalysis(cfg: ProgramCfg,
 
   val mapLattice: MapLattice[Variable | MemoryRegion, Set[Value], PowersetLattice[Value]] = MapLattice(powersetLattice)
 
-  val lattice: MapLattice[CfgNode, mapLattice.Element, mapLattice.type] = MapLattice(mapLattice)
+  val lattice: MapLattice[CfgNode, Map[Variable | MemoryRegion, Set[Value]], mapLattice.type] = MapLattice(mapLattice)
 
   val domain: Set[CfgNode] = cfg.nodes.toSet
 
@@ -98,7 +98,7 @@ trait ValueSetAnalysis(cfg: ProgramCfg,
 
   /** Default implementation of eval.
     */
-  def eval(cmd: Command, s: lattice.sublattice.Element, n: CfgNode): lattice.sublattice.Element = {
+  def eval(cmd: Command, s: Map[Variable | MemoryRegion, Set[Value]], n: CfgNode): Map[Variable | MemoryRegion, Set[Value]] = {
     Logger.debug(s"eval: $cmd")
     Logger.debug(s"state: $s")
     Logger.debug(s"node: $n")
@@ -159,7 +159,7 @@ trait ValueSetAnalysis(cfg: ProgramCfg,
 
   /** Transfer function for state lattice elements.
     */
-  def localTransfer(n: CfgNode, s: lattice.sublattice.Element): lattice.sublattice.Element = n match {
+  def localTransfer(n: CfgNode, s: Map[Variable | MemoryRegion, Set[Value]]): Map[Variable | MemoryRegion, Set[Value]] = n match {
     case entry: CfgFunctionEntryNode =>
       mmm.pushContext(entry.data.name)
       s
@@ -173,7 +173,7 @@ trait ValueSetAnalysis(cfg: ProgramCfg,
 
   /** Transfer function for state lattice elements. (Same as `localTransfer` for simple value analysis.)
     */
-  def transfer(n: CfgNode, s: lattice.sublattice.Element): lattice.sublattice.Element = localTransfer(n, s)
+  def transfer(n: CfgNode, s: Map[Variable | MemoryRegion, Set[Value]]): Map[Variable | MemoryRegion, Set[Value]] = localTransfer(n, s)
 }
 
 class ValueSetAnalysisSolver(

--- a/src/main/scala/analysis/VSA.scala
+++ b/src/main/scala/analysis/VSA.scala
@@ -183,6 +183,4 @@ class ValueSetAnalysisSolver(
     mmm: MemoryModelMap,
     constantProp: Map[CfgNode, Map[Variable, FlatElement[BitVecLiteral]]],
 ) extends ValueSetAnalysis(cfg, globals, externalFunctions, globalOffsets, subroutines, mmm, constantProp)
-    with SimpleMonotonicSolver[CfgNode, Map[Variable | MemoryRegion, Set[Value]], MapLattice[Variable | MemoryRegion, Set[Value], PowersetLattice[Value]]]
-    with ForwardDependencies
-
+    with InterproceduralMonotonicSolver[Map[Variable | MemoryRegion, Set[Value]], MapLattice[Variable | MemoryRegion, Set[Value], PowersetLattice[Value]]]

--- a/src/main/scala/analysis/VSA.scala
+++ b/src/main/scala/analysis/VSA.scala
@@ -45,6 +45,8 @@ trait ValueSetAnalysis(cfg: ProgramCfg,
 
   val domain: Set[CfgNode] = cfg.nodes.toSet
 
+  val first: Set[CfgNode] = Set(cfg.startNode)
+
   private val stackPointer = Register("R31", BitVecType(64))
   private val linkRegister = Register("R30", BitVecType(64))
   private val framePointer = Register("R29", BitVecType(64))
@@ -183,4 +185,5 @@ class ValueSetAnalysisSolver(
     mmm: MemoryModelMap,
     constantProp: Map[CfgNode, Map[Variable, FlatElement[BitVecLiteral]]],
 ) extends ValueSetAnalysis(cfg, globals, externalFunctions, globalOffsets, subroutines, mmm, constantProp)
-    with InterproceduralMonotonicSolver[Map[Variable | MemoryRegion, Set[Value]], MapLattice[Variable | MemoryRegion, Set[Value], PowersetLattice[Value]]]
+    with InterproceduralForwardDependencies
+    with SimpleMonotonicSolver[CfgNode, Map[Variable | MemoryRegion, Set[Value]], MapLattice[Variable | MemoryRegion, Set[Value], PowersetLattice[Value]]]

--- a/src/main/scala/analysis/solvers/FixPointSolver.scala
+++ b/src/main/scala/analysis/solvers/FixPointSolver.scala
@@ -5,25 +5,25 @@ import scala.collection.immutable.ListSet
 
 /** Base trait for lattice solvers.
   */
-trait LatticeSolver:
+trait LatticeSolver[T]:
 
   /** The lattice used by the solver.
     */
-  val lattice: Lattice
+  val lattice: Lattice[T]
 
   /** The analyze function.
     */
-  def analyze(intra: Boolean): lattice.Element
+  def analyze(intra: Boolean): T
 
 /** Base trait for map lattice solvers.
   * @tparam N
   *   type of the elements in the map domain.
   */
-trait MapLatticeSolver[N] extends LatticeSolver with Dependencies[N]:
+trait MapLatticeSolver[N, T, L <: Lattice[T]] extends LatticeSolver[Map[N, T]] with Dependencies[N]:
 
   /** Must be a map lattice.
     */
-  val lattice: MapLattice[N, Lattice]
+  val lattice: MapLattice[N, T, L]
 
   /** The transfer function.
     */
@@ -101,7 +101,7 @@ trait ListSetWorklist[N] extends Worklist[N]:
   * @tparam N
   *   type of the elements in the worklist.
   */
-trait WorklistFixpointSolver[N] extends MapLatticeSolver[N] with ListSetWorklist[N] with Dependencies[N]:
+trait WorklistFixpointSolver[N, T, L <: Lattice[T]] extends MapLatticeSolver[N, T, L] with ListSetWorklist[N] with Dependencies[N]:
   /** The current lattice element.
     */
   var x: lattice.Element = _
@@ -110,7 +110,7 @@ trait WorklistFixpointSolver[N] extends MapLatticeSolver[N] with ListSetWorklist
     val xn = x(n)
     val y = funsub(n, x, intra)
     if y != xn then
-      x += n -> y
+      x = x + (n -> y)
       add(outdep(n, intra))
 
 /** Worklist-based fixpoint solver.
@@ -118,7 +118,7 @@ trait WorklistFixpointSolver[N] extends MapLatticeSolver[N] with ListSetWorklist
   * @tparam N
   *   type of the elements in the worklist.
   */
-trait SimpleWorklistFixpointSolver[N] extends WorklistFixpointSolver[N]:
+trait SimpleWorklistFixpointSolver[N, T, L <: Lattice[T]] extends WorklistFixpointSolver[N, T, L]:
 
   /** The map domain.
     */
@@ -147,7 +147,7 @@ trait SimpleWorklistFixpointSolver[N] extends WorklistFixpointSolver[N]:
   * Better implementation of the same thing
   * https://github.com/cs-au-dk/TIP/blob/master/src/tip/solvers/FixpointSolvers.scala#L311
   */
-trait PushDownWorklistFixpointSolver[N] extends MapLatticeSolver[N] with ListSetWorklist[N] with Dependencies[N]:
+trait PushDownWorklistFixpointSolver[N, T, L <: Lattice[T]] extends MapLatticeSolver[N, T, L] with ListSetWorklist[N] with Dependencies[N]:
   /** The current lattice element.
     */
   var x: lattice.Element = _
@@ -178,7 +178,7 @@ trait PushDownWorklistFixpointSolver[N] extends MapLatticeSolver[N] with ListSet
   * @tparam N
   *   type of the elements in the worklist.
   */
-trait SimplePushDownWorklistFixpointSolver[N] extends PushDownWorklistFixpointSolver[N]:
+trait SimplePushDownWorklistFixpointSolver[N, T, L <: Lattice[T]] extends PushDownWorklistFixpointSolver[N, T, L]:
 
   /** The map domain.
     */

--- a/src/main/scala/analysis/solvers/FixPointSolver.scala
+++ b/src/main/scala/analysis/solvers/FixPointSolver.scala
@@ -27,7 +27,7 @@ trait MapLatticeSolver[N, T, L <: Lattice[T]] extends LatticeSolver[Map[N, T]] w
 
   /** The transfer function.
     */
-  def transfer(n: N, s: lattice.sublattice.Element): lattice.sublattice.Element
+  def transfer(n: N, s: T): T
 
   /** The constraint function for individual elements in the map domain. First computes the join of the incoming
     * elements and then applies the transfer function.
@@ -38,12 +38,12 @@ trait MapLatticeSolver[N, T, L <: Lattice[T]] extends LatticeSolver[Map[N, T]] w
     * @return
     *   the output sublattice element
     */
-  def funsub(n: N, x: lattice.Element): lattice.sublattice.Element =
+  def funsub(n: N, x: Map[N, T]): T =
     transfer(n, join(n, x))
 
   /** Computes the least upper bound of the incoming elements.
     */
-  def join(n: N, o: lattice.Element): lattice.sublattice.Element =
+  def join(n: N, o: Map[N, T]): T =
     val states = indep(n).map(o(_))
     states.foldLeft(lattice.sublattice.bottom)((acc, pred) => lattice.sublattice.lub(acc, pred))
 
@@ -82,12 +82,12 @@ trait ListSetWorklist[N] extends Worklist[N]:
 
   private var worklist = new ListSet[N]
 
-  def add(n: N) =
+  def add(n: N): Unit =
     worklist += n
 
-  def add(ns: Set[N]) = worklist ++= ns
+  def add(ns: Set[N]): Unit = worklist ++= ns
 
-  def run(first: Set[N]) =
+  def run(first: Set[N]): Unit =
     worklist = new ListSet[N] ++ first
     while worklist.nonEmpty do
       val n = worklist.head
@@ -102,9 +102,9 @@ trait ListSetWorklist[N] extends Worklist[N]:
 trait WorklistFixpointSolver[N, T, L <: Lattice[T]] extends MapLatticeSolver[N, T, L] with ListSetWorklist[N] with Dependencies[N]:
   /** The current lattice element.
     */
-  var x: lattice.Element = _
+  var x: Map[N, T] = _
 
-  def process(n: N) =
+  def process(n: N): Unit =
     val xn = x(n)
     val y = funsub(n, x)
     if y != xn then
@@ -130,7 +130,7 @@ trait SimpleWorklistFixpointSolver[N, T, L <: Lattice[T]] extends WorklistFixpoi
     *   the new lattice element
     */
 
-  def analyze(): lattice.Element =
+  def analyze(): Map[N, T] =
     x = lattice.bottom
     run(domain)
     x
@@ -148,12 +148,12 @@ trait SimpleWorklistFixpointSolver[N, T, L <: Lattice[T]] extends WorklistFixpoi
 trait PushDownWorklistFixpointSolver[N, T, L <: Lattice[T]] extends MapLatticeSolver[N, T, L] with ListSetWorklist[N] with Dependencies[N]:
   /** The current lattice element.
     */
-  var x: lattice.Element = _
+  var x: Map[N, T] = _
 
   /** Propagates lattice element y to node m.
     * https://github.com/cs-au-dk/TIP/blob/master/src/tip/solvers/FixpointSolvers.scala#L286
     */
-  def propagate(y: lattice.sublattice.Element, m: N) = {
+  def propagate(y: T, m: N): Unit = {
     val xm = x(m)
     val t = lattice.sublattice.lub(xm, y)
     if (t != xm) {
@@ -162,7 +162,7 @@ trait PushDownWorklistFixpointSolver[N, T, L <: Lattice[T]] extends MapLatticeSo
     }
   }
 
-  def process(n: N) =
+  def process(n: N): Unit =
     //val y = funsub(n, x, intra)
     val xn = x(n)
     val y = transfer(n, xn)
@@ -190,7 +190,7 @@ trait SimplePushDownWorklistFixpointSolver[N, T, L <: Lattice[T]] extends PushDo
     *   the new lattice element
     */
 
-  def analyze(): lattice.Element =
+  def analyze(): Map[N, T] =
     x = lattice.bottom
     run(domain)
     x

--- a/src/main/scala/analysis/solvers/FixPointSolver.scala
+++ b/src/main/scala/analysis/solvers/FixPointSolver.scala
@@ -1,6 +1,6 @@
 package analysis.solvers
 
-import analysis._
+import analysis.*
 import scala.collection.immutable.ListSet
 import scala.collection.mutable.LinkedHashSet
 
@@ -86,7 +86,7 @@ trait Worklist[N]:
   */
 trait ListSetWorklist[N] extends Worklist[N]:
 
-  private var worklist = new ListSet[N]
+  private var worklist = ListSet[N]()
 
   def add(n: N): Unit =
     worklist += n
@@ -107,19 +107,19 @@ trait ListSetWorklist[N] extends Worklist[N]:
   *   type of the elements in the worklist.
   */
 trait LinkedHashSetWorklist[N] extends Worklist[N]:
-  private val worklist = new LinkedHashSet[N]
+  private val worklist = LinkedHashSet[N]()
 
-  def add(n: N) =
+  def add(n: N): Unit =
     worklist += n
 
-  def add(ns: Set[N]) = worklist ++= ns
+  def add(ns: Set[N]): Unit = worklist ++= ns
 
-  def run(first: Set[N], intra: Boolean) =
-    worklist.addAll(first);
-    while (worklist.nonEmpty) do
-      val n = worklist.head;
+  def run(first: Set[N]): Unit =
+    worklist.addAll(first)
+    while worklist.nonEmpty do
+      val n = worklist.head
       worklist.remove(n)
-      process(n, intra)
+      process(n)
 
 
 /** Base trait for worklist-based fixpoint solvers.

--- a/src/main/scala/analysis/solvers/MonotonicSolver.scala
+++ b/src/main/scala/analysis/solvers/MonotonicSolver.scala
@@ -13,35 +13,45 @@ import scala.collection.mutable
   * TODO: investigate how to visit all reachable nodes at least once, then remove loopEscape. TODO: in longer term, add
   * a worklist to avoid processing nodes twice.
   */
-trait SimpleMonotonicSolver[N, T, L <: Lattice[T]] extends MapLatticeSolver[N, T, L] with ListSetWorklist[N] with Dependencies[N]:
+trait SimpleMonotonicSolver[T, L <: Lattice[T]] extends MapLatticeSolver[CfgNode, T, L] with ListSetWorklist[CfgNode] with Dependencies[CfgNode] {
   /** The current lattice element.
     */
-  var x: Map[N, T] = _
+  var x: Map[CfgNode, T] = _
 
   /** The map domain.
     */
-  val domain: Set[N]
+  val domain: Set[CfgNode]
 
-  private val loopEscape: mutable.Set[N] = mutable.Set.empty
+  private val loopEscape: mutable.Set[CfgNode] = mutable.Set.empty
 
-  def process(n: N, intra: Boolean): Unit =
+  def process(n: CfgNode): Unit =
     val xn = x(n)
-    val y = funsub(n, x, intra)
+    val y = funsub(n, x)
     if y != xn || !loopEscape.contains(n) then
       loopEscape.add(n)
       x += n -> y
-      add(outdep(n, intra))
+      add(outdep(n))
+}
 
-  def analyze(intra: Boolean): Map[N, T] =
+
+trait IntraproceduralMonotonicSolver[T, L <: Lattice[T]] extends SimpleMonotonicSolver[T, L] with IntraproceduralForwardDependencies {
+
+  def analyze(): Map[CfgNode, T] = {
     // TODO this sort of type-dependent code should not be in the generic solver
     // should probably base it upon WorklistFixpointSolverWithReachability from TIP instead?
-    val first: Set[N] = if (intra) {
-      domain.collect { case n: CfgFunctionEntryNode if n.pred(intra).isEmpty => n }
-    } else {
-      // TODO this is not the correct way to do things, we should set Cfg.startNode but don't have visibility here
-      domain.collect { case n: CfgFunctionEntryNode if n.data.name == "main" => n }
-    }
-
+    val first: Set[CfgNode] = domain.collect { case n: CfgFunctionEntryNode if n.pred(true).isEmpty => n }
     x = lattice.bottom
-    run(first, intra)
+    run(first)
     x
+  }
+}
+
+trait InterproceduralMonotonicSolver[T, L <: Lattice[T]] extends SimpleMonotonicSolver[T, L] with InterproceduralForwardDependencies {
+  def analyze(): Map[CfgNode, T] =
+    // TODO this sort of type-dependent code should not be in the generic solver
+    // should probably base it upon WorklistFixpointSolverWithReachability from TIP instead?
+    val first: Set[CfgNode] = domain.collect { case n: CfgFunctionEntryNode if n.data.name == "main" => n }
+    x = lattice.bottom
+    run(first)
+    x
+}

--- a/src/main/scala/analysis/solvers/MonotonicSolver.scala
+++ b/src/main/scala/analysis/solvers/MonotonicSolver.scala
@@ -13,10 +13,10 @@ import scala.collection.mutable
   * TODO: investigate how to visit all reachable nodes at least once, then remove loopEscape. TODO: in longer term, add
   * a worklist to avoid processing nodes twice.
   */
-trait SimpleMonotonicSolver[N] extends MapLatticeSolver[N] with ListSetWorklist[N] with Dependencies[N]:
+trait SimpleMonotonicSolver[N, T, L <: Lattice[T]] extends MapLatticeSolver[N, T, L] with ListSetWorklist[N] with Dependencies[N]:
   /** The current lattice element.
     */
-  var x: lattice.Element = _
+  var x: Map[N, T] = _
 
   /** The map domain.
     */
@@ -32,7 +32,7 @@ trait SimpleMonotonicSolver[N] extends MapLatticeSolver[N] with ListSetWorklist[
       x += n -> y
       add(outdep(n, intra))
 
-  def analyze(intra: Boolean): lattice.Element =
+  def analyze(intra: Boolean): Map[N, T] =
     // TODO this sort of type-dependent code should not be in the generic solver
     // should probably base it upon WorklistFixpointSolverWithReachability from TIP instead?
     val first: Set[N] = if (intra) {

--- a/src/main/scala/analysis/solvers/MonotonicSolver.scala
+++ b/src/main/scala/analysis/solvers/MonotonicSolver.scala
@@ -39,7 +39,7 @@ trait IntraproceduralMonotonicSolver[T, L <: Lattice[T]] extends SimpleMonotonic
   def analyze(): Map[CfgNode, T] = {
     // TODO this sort of type-dependent code should not be in the generic solver
     // should probably base it upon WorklistFixpointSolverWithReachability from TIP instead?
-    val first: Set[CfgNode] = domain.collect { case n: CfgFunctionEntryNode if n.pred(true).isEmpty => n }
+    val first: Set[CfgNode] = domain.collect { case n: CfgFunctionEntryNode if n.predIntra.isEmpty => n }
     x = lattice.bottom
     run(first)
     x

--- a/src/main/scala/analysis/solvers/MonotonicSolver.scala
+++ b/src/main/scala/analysis/solvers/MonotonicSolver.scala
@@ -13,45 +13,28 @@ import scala.collection.mutable
   * TODO: investigate how to visit all reachable nodes at least once, then remove loopEscape. TODO: in longer term, add
   * a worklist to avoid processing nodes twice.
   */
-trait SimpleMonotonicSolver[T, L <: Lattice[T]] extends MapLatticeSolver[CfgNode, T, L] with ListSetWorklist[CfgNode] with Dependencies[CfgNode] {
+trait SimpleMonotonicSolver[A, T, L <: Lattice[T]] extends MapLatticeSolver[A, T, L] with ListSetWorklist[A] with Dependencies[A] {
   /** The current lattice element.
     */
-  var x: Map[CfgNode, T] = _
+  var x: Map[A, T] = _
 
   /** The map domain.
     */
-  val domain: Set[CfgNode]
+  val first: Set[A]
 
-  private val loopEscape: mutable.Set[CfgNode] = mutable.Set.empty
+  private val loopEscape: mutable.Set[A] = mutable.Set.empty
 
-  def process(n: CfgNode): Unit =
+  def process(n: A): Unit =
     val xn = x(n)
     val y = funsub(n, x)
     if y != xn || !loopEscape.contains(n) then
       loopEscape.add(n)
       x += n -> y
       add(outdep(n))
-}
 
-
-trait IntraproceduralMonotonicSolver[T, L <: Lattice[T]] extends SimpleMonotonicSolver[T, L] with IntraproceduralForwardDependencies {
-
-  def analyze(): Map[CfgNode, T] = {
-    // TODO this sort of type-dependent code should not be in the generic solver
-    // should probably base it upon WorklistFixpointSolverWithReachability from TIP instead?
-    val first: Set[CfgNode] = domain.collect { case n: CfgFunctionEntryNode if n.predIntra.isEmpty => n }
+  def analyze(): Map[A, T] = {
     x = lattice.bottom
     run(first)
     x
   }
-}
-
-trait InterproceduralMonotonicSolver[T, L <: Lattice[T]] extends SimpleMonotonicSolver[T, L] with InterproceduralForwardDependencies {
-  def analyze(): Map[CfgNode, T] =
-    // TODO this sort of type-dependent code should not be in the generic solver
-    // should probably base it upon WorklistFixpointSolverWithReachability from TIP instead?
-    val first: Set[CfgNode] = domain.collect { case n: CfgFunctionEntryNode if n.data.name == "main" => n }
-    x = lattice.bottom
-    run(first)
-    x
 }

--- a/src/main/scala/ir/Interpreter.scala
+++ b/src/main/scala/ir/Interpreter.scala
@@ -1,5 +1,4 @@
-//package ir
-/*
+package ir
 import analysis.BitVectorEval.*
 import util.Logger
 
@@ -15,7 +14,7 @@ class Interpreter() {
   private var nextBlock: Option[Block] = None
   private val returnBlock: mutable.Stack[Block] = mutable.Stack()
 
-  def eval(exp: Expr, env: mutable.Map[Variable, BitVecLiteral]): Literal = {
+  def eval(exp: Expr, env: mutable.Map[Variable, BitVecLiteral]): BitVecLiteral = {
     exp match {
       case id: Variable =>
         env.get(id) match {
@@ -47,16 +46,11 @@ class Interpreter() {
 
       case r: Repeat =>
         Logger.debug(s"\t$r")
-        val arg = eval(r.body, env)
-        var result = arg
-        for (_ <- 1 to r.repeats) {
-          result = smt_concat(result, arg)
-        }
-        result
+        ??? // TODO
 
       case bin: BinaryExpr =>
-        val left: BitVecLiteral = eval(bin.arg1, env).asInstanceOf[BitVecLiteral]
-        val right: BitVecLiteral = eval(bin.arg2, env).asInstanceOf[BitVecLiteral]
+        val left = eval(bin.arg1, env)
+        val right = eval(bin.arg2, env)
         Logger.debug(
           s"\tBinaryExpr(0x${left.value.toString(16)}[u${left.size}] ${bin.op} 0x${right.value.toString(16)}[u${right.size}])"
         )
@@ -69,27 +63,18 @@ class Interpreter() {
           case BVUREM   => smt_bvurem(left, right)
           case BVSHL    => smt_bvshl(left, right)
           case BVLSHR   => smt_bvlshr(left, right)
-          case BVULT    => smt_bvult(left, right)
-          case BVNAND   => ???
-          case BVNOR    => ???
-          case BVXOR    => ???
-          case BVXNOR   => ???
+          case BVNAND   => smt_bvnand(left, right)
+          case BVNOR    => smt_bvnor(left, right)
+          case BVXOR    => smt_bvxor(left, right)
+          case BVXNOR   => smt_bvxnor(left, right)
           case BVCOMP   => smt_bvcomp(left, right)
           case BVSUB    => smt_bvsub(left, right)
           case BVSDIV   => smt_bvsdiv(left, right)
           case BVSREM   => smt_bvsrem(left, right)
-          case BVSMOD   => ???
+          case BVSMOD   => smt_bvsmod(left, right)
           case BVASHR   => smt_bvashr(left, right)
-          case BVULE    => smt_bvule(left, right)
-          case BVUGT    => ???
-          case BVUGE    => ???
-          case BVSLT    => smt_bvslt(left, right)
-          case BVSLE    => smt_bvsle(left, right)
-          case BVSGT    => ???
-          case BVSGE    => ???
-          case BVEQ     => smt_bveq(left, right)
-          case BVNEQ    => smt_bvneq(left, right)
           case BVCONCAT => smt_concat(left, right)
+          case _ => ???
         }
 
       case un: UnaryExpr =>
@@ -98,8 +83,6 @@ class Interpreter() {
         un.op match {
           case BVNEG   => smt_bvneg(arg)
           case BVNOT   => smt_bvnot(arg)
-          case IntNEG  => ???
-          case BoolNOT => ???
         }
 
       case m: Memory =>
@@ -108,15 +91,86 @@ class Interpreter() {
 
       case ml: MemoryLoad =>
         Logger.debug(s"\t$ml")
-        val index: Int = eval(ml.index, env).asInstanceOf[BitVecLiteral].value.toInt
+        val index: Int = eval(ml.index, env).value.toInt
         getMemory(index, ml.size, ml.endian, mems)
 
       case ms: MemoryStore =>
-        val index: Int = eval(ms.index, env).asInstanceOf[BitVecLiteral].value.toInt
-        val value: BitVecLiteral = eval(ms.value, env).asInstanceOf[BitVecLiteral]
+        val index: Int = eval(ms.index, env).value.toInt
+        val value: BitVecLiteral = eval(ms.value, env)
         Logger.debug(s"\tMemoryStore(mem:${ms.mem}, index:0x${index.toHexString}, value:0x${value.value
           .toString(16)}[u${value.size}], size:${ms.size})")
         setMemory(index, ms.size, ms.endian, value, mems)
+    }
+  }
+
+  def evalBool(exp: Expr, env: mutable.Map[Variable, BitVecLiteral]): BoolLit = {
+    exp match {
+      case n: BoolLit => n
+      case bin: BinaryExpr =>
+        bin.op match {
+          case b: BoolBinOp =>
+            val arg1 = evalBool(bin.arg1, env)
+            val arg2 = evalBool(bin.arg2, env)
+            b match {
+              case BoolEQ =>
+                if (arg1 == arg2) {
+                  TrueLiteral
+                } else {
+                  FalseLiteral
+                }
+              case BoolNEQ =>
+                if (arg1 != arg2) {
+                  TrueLiteral
+                } else {
+                  FalseLiteral
+                }
+              case BoolAND =>
+                (arg1, arg2) match {
+                  case (TrueLiteral, TrueLiteral) => TrueLiteral
+                  case _ => FalseLiteral
+                }
+              case BoolOR =>
+                (arg1, arg2) match {
+                  case (FalseLiteral, FalseLiteral) => FalseLiteral
+                  case _ => TrueLiteral
+                }
+              case BoolIMPLIES =>
+                (arg1, arg2) match {
+                  case (TrueLiteral, FalseLiteral) => FalseLiteral
+                  case _ => TrueLiteral
+                }
+              case BoolEQUIV =>
+                if (arg1 == arg2) {
+                  TrueLiteral
+                } else {
+                  FalseLiteral
+                }
+            }
+          case b: BVBinOp =>
+            val left = eval(bin.arg1, env)
+            val right = eval(bin.arg2, env)
+            b match {
+              case BVULT => smt_bvult(left, right)
+              case BVULE => smt_bvule(left, right)
+              case BVUGT => smt_bvugt(left, right)
+              case BVUGE => smt_bvuge(left, right)
+              case BVSLT => smt_bvslt(left, right)
+              case BVSLE => smt_bvsle(left, right)
+              case BVSGT => smt_bvsgt(left, right)
+              case BVSGE => smt_bvsge(left, right)
+              case BVEQ => smt_bveq(left, right)
+              case BVNEQ => smt_bvneq(left, right)
+              case _ => ???
+            }
+          case _ => ???
+        }
+
+      case un: UnaryExpr =>
+        un.op match {
+          case BoolNOT => if evalBool(un.arg, env) == TrueLiteral then FalseLiteral else TrueLiteral
+          case _ => ???
+        }
+
     }
   }
 
@@ -179,7 +233,7 @@ class Interpreter() {
   }
 
   private def interpretBlock(b: Block): Unit = {
-    Logger.debug(s"Block:${nextBlock.get.label} ${nextBlock.get.address}")
+    Logger.debug(s"Block:${b.label} ${b.address}")
     // Block.Statement
     for ((statement, index) <- b.statements.zipWithIndex) {
       Logger.debug(s"statement[$index]:")
@@ -195,7 +249,7 @@ class Interpreter() {
           for (g <- gt.targets) {
             val condition: Option[Expr] = g.statements.headOption.collect { case a: Assume => a.body }
             condition match {
-              case Some(e) => eval(e, regs) match {
+              case Some(e) => evalBool(e, regs) match {
                 case TrueLiteral =>
                   nextBlock = Some(g)
                   break
@@ -235,21 +289,13 @@ class Interpreter() {
       case assign: LocalAssign =>
         Logger.debug(s"LocalAssign ${assign.lhs} = ${assign.rhs}")
         val evalRight = eval(assign.rhs, regs)
-        evalRight match {
-          case BitVecLiteral(value, size) =>
-            Logger.debug(s"LocalAssign ${assign.lhs} := 0x${value.toString(16)}[u$size]\n")
-            regs += (assign.lhs -> BitVecLiteral(value, size))
-          case _ => throw new Exception("cannot register non-bitvectors")
-        }
+        Logger.debug(s"LocalAssign ${assign.lhs} := 0x${evalRight.value.toString(16)}[u${evalRight.size}]\n")
+        regs += (assign.lhs -> evalRight)
 
       case assign: MemoryAssign =>
         Logger.debug(s"MemoryAssign ${assign.lhs} = ${assign.rhs}")
         val evalRight = eval(assign.rhs, regs)
-        evalRight match {
-          case BitVecLiteral(value, size) =>
-            Logger.debug(s"MemoryAssign ${assign.lhs} := 0x${value.toString(16)}[u$size]\n")
-          case _ => throw new Exception("cannot register non-bitvectors")
-        }
+        Logger.debug(s"MemoryAssign ${assign.lhs} := 0x${evalRight.value.toString(16)}[u$evalRight.size]\n")
 
       case assert: Assert =>
         Logger.debug(assert)
@@ -291,4 +337,3 @@ class Interpreter() {
     regs
   }
 }
-*/

--- a/src/main/scala/ir/Interpreter.scala
+++ b/src/main/scala/ir/Interpreter.scala
@@ -1,5 +1,5 @@
-package ir
-
+//package ir
+/*
 import analysis.BitVectorEval.*
 import util.Logger
 
@@ -291,3 +291,4 @@ class Interpreter() {
     regs
   }
 }
+*/

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -147,14 +147,14 @@ object RunUtils {
 
     Logger.info("[!] Running Constant Propagation")
     val constPropSolver = ConstantPropagationSolver(cfg)
-    val constPropResult = constPropSolver.analyze(true)
+    val constPropResult = constPropSolver.analyze()
 
     config.analysisDotPath.foreach(s => writeToFile(cfg.toDot(Output.labeler(constPropResult, true), Output.dotIder), s"${s}_constprop$iteration.dot"))
     config.analysisResultsPath.foreach(s => writeToFile(printAnalysisResults(cfg, constPropResult, iteration), s"${s}_constprop$iteration.txt"))
 
     Logger.info("[!] Running MRA")
     val mraSolver = MemoryRegionAnalysisSolver(cfg, globalAddresses, globalOffsets, mergedSubroutines, constPropResult)
-    val mraResult: Map[CfgNode, Set[MemoryRegion]] = mraSolver.analyze(true)
+    val mraResult: Map[CfgNode, Set[MemoryRegion]] = mraSolver.analyze()
     memoryRegionAnalysisResults = mraResult
 
     config.analysisDotPath.foreach(s => writeToFile(cfg.toDot(Output.labeler(mraResult, true), Output.dotIder), s"${s}_mra$iteration.dot"))
@@ -166,7 +166,7 @@ object RunUtils {
 
     Logger.info("[!] Running VSA")
     val vsaSolver = ValueSetAnalysisSolver(cfg, globalAddresses, externalAddresses, globalOffsets, subroutines, mmm, constPropResult)
-    val vsaResult: Map[CfgNode, Map[Variable | MemoryRegion, Set[Value]]]  = vsaSolver.analyze(false)
+    val vsaResult: Map[CfgNode, Map[Variable | MemoryRegion, Set[Value]]]  = vsaSolver.analyze()
 
     config.analysisDotPath.foreach(s => writeToFile(cfg.toDot(Output.labeler(vsaResult, true), Output.dotIder), s"${s}_vsa$iteration.dot"))
     config.analysisResultsPath.foreach(s => writeToFile(printAnalysisResults(cfg, vsaResult, iteration), s"${s}_vsa$iteration.txt"))

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -153,7 +153,7 @@ object RunUtils {
     config.analysisResultsPath.foreach(s => writeToFile(printAnalysisResults(cfg, constPropResult, iteration), s"${s}_constprop$iteration.txt"))
 
     Logger.info("[!] Running MRA")
-    val mraSolver = MemoryRegionAnalysis.WorklistSolver(cfg, globalAddresses, globalOffsets, mergedSubroutines, constPropResult)
+    val mraSolver = MemoryRegionAnalysisSolver(cfg, globalAddresses, globalOffsets, mergedSubroutines, constPropResult)
     val mraResult: Map[CfgNode, Set[MemoryRegion]] = mraSolver.analyze(true)
     memoryRegionAnalysisResults = mraResult
 
@@ -165,8 +165,7 @@ object RunUtils {
     mmm.convertMemoryRegions(mraResult, mergedSubroutines)
 
     Logger.info("[!] Running VSA")
-    val vsaSolver =
-      ValueSetAnalysis.WorklistSolver(cfg, globalAddresses, externalAddresses, globalOffsets, subroutines, mmm, constPropResult)
+    val vsaSolver = ValueSetAnalysisSolver(cfg, globalAddresses, externalAddresses, globalOffsets, subroutines, mmm, constPropResult)
     val vsaResult: Map[CfgNode, Map[Variable | MemoryRegion, Set[Value]]]  = vsaSolver.analyze(false)
 
     config.analysisDotPath.foreach(s => writeToFile(cfg.toDot(Output.labeler(vsaResult, true), Output.dotIder), s"${s}_vsa$iteration.dot"))

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -218,7 +218,7 @@ object RunUtils {
               isEntryNode = false
             case _ => isEntryNode = false
           }
-          val successors = next.succ(true)
+          val successors = next.succIntra
           if (successors.size > 1) {
             val successorsCmd = successors.collect { case c: CfgCommandNode => c }.toSeq.sortBy(_.data.label)
             printGoTo(successorsCmd)
@@ -272,14 +272,14 @@ object RunUtils {
   ): (Program, Boolean) = {
     var modified: Boolean = false
     val worklist = ListBuffer[CfgNode]()
-    cfg.startNode.succ(true).union(cfg.startNode.succ(false)).foreach(node => worklist.addOne(node))
+    cfg.startNode.succIntra.union(cfg.startNode.succInter).foreach(node => worklist.addOne(node))
 
     val visited = MutableSet[CfgNode]()
     while (worklist.nonEmpty) {
       val node = worklist.remove(0)
       if (!visited.contains(node)) {
         process(node)
-        node.succ(true).union(node.succ(false)).foreach(node => worklist.addOne(node))
+        node.succIntra.union(node.succInter).foreach(node => worklist.addOne(node))
         visited.add(node)
       }
     }

--- a/src/main/scala/util/RunUtils.scala
+++ b/src/main/scala/util/RunUtils.scala
@@ -154,7 +154,7 @@ object RunUtils {
 
     Logger.info("[!] Running MRA")
     val mraSolver = MemoryRegionAnalysisSolver(cfg, globalAddresses, globalOffsets, mergedSubroutines, constPropResult)
-    val mraResult: Map[CfgNode, Set[MemoryRegion]] = mraSolver.analyze()
+    val mraResult = mraSolver.analyze()
     memoryRegionAnalysisResults = mraResult
 
     config.analysisDotPath.foreach(s => writeToFile(cfg.toDot(Output.labeler(mraResult, true), Output.dotIder), s"${s}_mra$iteration.dot"))
@@ -166,7 +166,7 @@ object RunUtils {
 
     Logger.info("[!] Running VSA")
     val vsaSolver = ValueSetAnalysisSolver(cfg, globalAddresses, externalAddresses, globalOffsets, subroutines, mmm, constPropResult)
-    val vsaResult: Map[CfgNode, Map[Variable | MemoryRegion, Set[Value]]]  = vsaSolver.analyze()
+    val vsaResult = vsaSolver.analyze()
 
     config.analysisDotPath.foreach(s => writeToFile(cfg.toDot(Output.labeler(vsaResult, true), Output.dotIder), s"${s}_vsa$iteration.dot"))
     config.analysisResultsPath.foreach(s => writeToFile(printAnalysisResults(cfg, vsaResult, iteration), s"${s}_vsa$iteration.txt"))

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -1,4 +1,3 @@
-/*
 package ir
 
 import analysis.BitVectorEval.*
@@ -192,4 +191,3 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
     testInterpret("no_interference_update_y", expected)
   }
 }
-*/

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -1,3 +1,4 @@
+/*
 package ir
 
 import analysis.BitVectorEval.*
@@ -191,3 +192,4 @@ class InterpreterTests extends AnyFunSuite with BeforeAndAfter {
     testInterpret("no_interference_update_y", expected)
   }
 }
+*/


### PR DESCRIPTION
This is a number of changes to the analysis code.

One of the main changes is making all the types in the analysis explicitly declared instead of relying on a maze of .Elements with convoluted inheritance patterns. I personally find this makes the code easier to follow. I am curious for feedback here from @ailrst and @yousifpatti  - is this an improvement? 

Other changes here:
- Consolidates and cleans up parts of the analysis, to reduce the convoluted inheritance patterns
- Enables procedure inlining in the CFG so that there are actually interprocedural edges in the CFG
- Makes interprocedural analyses actually use the interprocedural edges (before they were in practice not meaningly different from the intraprocedural analyses) but this still doesn't seem to be completely working properly, there might be an issue with the inlining? It might make sense to just make the VSA an intraprocedural analysis for now? It isn't worth trying to fix the inlining since #141 is in the works.
- Removes edges from the CFG (no longer necessary now that jumps don't have conditions)
- Significantly improves the way intra/interprocedural analyses are handled so there isn't a boolean 'intra' flag carried around everywhere
- Makes the SimpleMonotonicSolver obtain its initial set of nodes in a more modular way.


