### PR TITLE
Runutils cleanup

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -56,7 +56,7 @@ object basil extends RootModule with ScalaModule with antlr.AntlrModule {
             if (verified == shouldVerify) {
               if (os.exists(outPath) && !(os.exists(expectedPath) && filesContentEqual(outPath, expectedPath))) {
                 println(s"updated $expectedPath")
-                os.copy(outPath, expectedPath)
+                os.copy.over(outPath, expectedPath)
               }
             }
           }

--- a/src/main/scala/ir/IRCursor.scala
+++ b/src/main/scala/ir/IRCursor.scala
@@ -22,7 +22,6 @@ trait IRWalk[IN <: CFGPosition, NT <: CFGPosition & IN] {
 
 object IRWalk:
   def procedure(pos: CFGPosition) : Procedure = {
-    Logger.info(s"pos: $pos")
     pos match {
       case p: Procedure => p
       case b: Block => b.parent

--- a/src/main/scala/util/Logging.scala
+++ b/src/main/scala/util/Logging.scala
@@ -10,7 +10,7 @@ enum LogLevel(val id: Int):
   case ERROR extends LogLevel(3)
 
 object Logger:
-  private var level: LogLevel = LogLevel.DEBUG
+  private var level: LogLevel = LogLevel.INFO
   import LogLevel.*
 
   def write(

--- a/src/test/analysis/livevars/dump/livevar_analysis_results
+++ b/src/test/analysis/livevars/dump/livevar_analysis_results
@@ -1,0 +1,35 @@
+%00000579: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 24bv64), Register(R0, bv64)[32:0], LittleEndian, 32)==>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+%000003c4: Register(R0, bv64) := ZeroExtend(32, MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 12bv64), LittleEndian, 32))==>Register(R30, bv64)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+%000003bd: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 24bv64), 0bv32, LittleEndian, 32)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%000003e8: Register(R0, bv64) := 2bv64==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+Block lmain_goto_l0000056e==>Register(R30, bv64)->Top<>LocalVar(ZF, bv1)->Top<>Register(R31, bv64)->Top
+%000003fd: Register(R0, bv64) := ZeroExtend(32, bvadd32(Register(R0, bv64)[32:0], 1bv32))==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+%00000412: Register(R31, bv64) := bvadd64(Register(R31, bv64), 32bv64)==>Register(R30, bv64)->Top
+%0000057d: GoTo(l000003f2)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%00000865: GoTo(l000003f2)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+GoTo(l0000056e)==>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+GoTo(l000003e0)==>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+GoTo(main_basil_return)==>Register(R30, bv64)->Top
+%000003d4: LocalVar(CF, bv1) := bvnot1(bvcomp33(ZeroExtend(1, LocalVar(#6, bv32)), bvadd33(ZeroExtend(1, Register(R0, bv64)[32:0]), 4294967296bv33)))==>Register(R31, bv64)->Top<>LocalVar(#6, bv32)->Top<>Register(R30, bv64)->Top
+Block lmain==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top<>Register(R0, bv64)->Top<>Register(R30, bv64)->Top
+%000003f0: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 24bv64), Register(R0, bv64)[32:0], LittleEndian, 32)==>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+%000003ca: LocalVar(#6, bv32) := bvadd32(Register(R0, bv64)[32:0], 0bv32)==>LocalVar(#6, bv32)->Top<>Register(R0, bv64)->Top<>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%0000040c: Register(R0, bv64) := ZeroExtend(32, MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 28bv64), LittleEndian, 32))==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+assume (bvnot1(bvcomp1(LocalVar(ZF, bv1), 1bv1)) != 0bv1)None==>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+assume (bvnot1(bvcomp1(LocalVar(ZF, bv1), 1bv1)) == 0bv1)None==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+Block main_basil_return==>Register(R30, bv64)->Top
+%000003e2: GoTo(lmain_goto_l000003e0, lmain_goto_l0000056e)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top<>LocalVar(ZF, bv1)->Top
+%000003f7: Register(R0, bv64) := ZeroExtend(32, MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 24bv64), LittleEndian, 32))==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+%000003b6: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), Register(R31, bv64), Register(R1, bv64), LittleEndian, 64)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%00000571: Register(R0, bv64) := 1bv64==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top<>Register(R30, bv64)->Top
+Procedure main at 1820 with 7 blocks and 2 in and 2 out parameters==>Register(R30, bv64)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+Block l0000056e==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+Block l000003e0==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%000003ae: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 12bv64), Register(R0, bv64)[32:0], LittleEndian, 32)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+%000003a6: Register(R31, bv64) := bvadd64(Register(R31, bv64), 18446744073709551584bv64)==>Register(R30, bv64)->Top<>Register(R1, bv64)->Top<>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+Block lmain_goto_l000003e0==>Register(R30, bv64)->Top<>LocalVar(ZF, bv1)->Top<>Register(R31, bv64)->Top
+Block l000003f2==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%000003cf: LocalVar(VF, bv1) := bvnot1(bvcomp33(SignExtend(1, LocalVar(#6, bv32)), bvadd33(SignExtend(1, Register(R0, bv64)[32:0]), 0bv33)))==>Register(R30, bv64)->Top<>LocalVar(#6, bv32)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+%000003d8: LocalVar(ZF, bv1) := bvcomp32(LocalVar(#6, bv32), 0bv32)==>Register(R30, bv64)->Top<>LocalVar(#6, bv32)->Top<>Register(R31, bv64)->Top<>LocalVar(ZF, bv1)->Top
+%000003dc: LocalVar(NF, bv1) := LocalVar(#6, bv32)[32:31]==>Register(R31, bv64)->Top<>LocalVar(ZF, bv1)->Top<>Register(R30, bv64)->Top
+%00000405: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 28bv64), Register(R0, bv64)[32:0], LittleEndian, 32)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top

--- a/src/test/analysis/livevars/dump/param_analysis_results
+++ b/src/test/analysis/livevars/dump/param_analysis_results
@@ -1,0 +1,1 @@
+Procedure main at 1820 with 7 blocks and 2 in and 2 out parameters->R1,R0,

--- a/src/test/analysis/params/dump/livevar_analysis_results
+++ b/src/test/analysis/params/dump/livevar_analysis_results
@@ -1,0 +1,85 @@
+%000005ca: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R0, bv64), 4064bv64), LittleEndian, 64)==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top<>Register(R1, bv64)->Top
+%00000614: Register(R29, bv64) := MemoryLoad(Memory(mem, 64, 8), Register(R31, bv64), LittleEndian, 64)==>Register(R31, bv64)->Top
+%000005e3: LocalVar(#8, bv64) := bvadd64(bvadd64(Register(R2, bv64), bvnot64(Register(R3, bv64))), 1bv64)==>Register(R1, bv64)->Top<>LocalVar(#7, bv64)->Top<>Register(R31, bv64)->Top<>Register(R2, bv64)->Top<>LocalVar(#8, bv64)->Top
+%000005f3: LocalVar(ZF, bv1) := bvcomp64(LocalVar(#8, bv64), 0bv64)==>LocalVar(ZF, bv1)->Top<>Register(R1, bv64)->Top<>Register(R31, bv64)->Top<>LocalVar(#8, bv64)->Top
+%00000586: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R2, bv64), 16bv64), Register(R0, bv64), LittleEndian, 64)==>Register(R31, bv64)->Top
+%00000539: Register(R1, bv64) := MemoryLoad(Memory(mem, 64, 8), Register(R0, bv64), LittleEndian, 64)==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+%0000051e: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 28bv64), Register(R0, bv64)[32:0], LittleEndian, 32)==>Register(R1, bv64)->Top<>Register(R31, bv64)->Top
+Block lsub_seven==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%000005ab: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 48bv64), LittleEndian, 64)==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+Block l00000597==>Register(R31, bv64)->Top
+%00000546: Register(R1, bv64) := 0bv64==>Register(R31, bv64)->Top
+%00000595: DirectCall(sub_seven, Some(l00000597))==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%000004d9: Register(R0, bv64) := ZeroExtend(32, MemoryLoad(Memory(mem, 64, 8), Register(R0, bv64), LittleEndian, 32))==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top<>Register(R30, bv64)->Top
+%00000569: Register(R1, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R3, bv64), 8bv64), LittleEndian, 64)==>Register(R2, bv64)->Top<>Register(R1, bv64)->Top<>Register(R3, bv64)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+%0000061d: Register(R31, bv64) := bvadd64(Register(R31, bv64), 64bv64)==>Register(R30, bv64)->Top
+%000005a4: IndirectCall(Register(R0, bv64), Some(l000005a6))==>Register(R31, bv64)->Top
+Block lmain==>Register(R1, bv64)->Top<>Register(R30, bv64)->Top<>Register(R29, bv64)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+%000005d8: Register(R3, bv64) := MemoryLoad(Memory(mem, 64, 8), Register(R0, bv64), LittleEndian, 64)==>Register(R1, bv64)->Top<>Register(R3, bv64)->Top<>Register(R2, bv64)->Top<>Register(R31, bv64)->Top
+%00000592: Register(R30, bv64) := 2292bv64==>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+assume (bvcomp1(LocalVar(ZF, bv1), 1bv1) != 0bv1)None==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+Block l000005a6==>Register(R31, bv64)->Top
+%0000077a: Register(R0, bv64) := 65536bv64==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top<>Register(R1, bv64)->Top
+%0000059c: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 40bv64), LittleEndian, 64)==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+%0000054b: Register(R0, bv64) := 69632bv64==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+%00000600: Register(R3, bv64) := 0bv64==>Register(R31, bv64)->Top<>LocalVar(ZF, bv1)->Top<>Register(R1, bv64)->Top
+%000004d2: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R0, bv64), 4040bv64), LittleEndian, 64)==>Register(R0, bv64)->Top<>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+GoTo(l00000604)==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+Block main_basil_return==>Register(R30, bv64)->Top
+%0000052b: Register(R0, bv64) := 65536bv64==>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+%00000551: Register(R0, bv64) := bvadd64(Register(R0, bv64), 24bv64)==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+%00000781: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R0, bv64), 4048bv64), LittleEndian, 64)==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top<>Register(R0, bv64)->Top
+GoTo(l00000597)==>Register(R31, bv64)->Top
+%00000516: Register(R29, bv64) := Register(R31, bv64)==>Register(R0, bv64)->Top<>Register(R1, bv64)->Top<>Register(R31, bv64)->Top
+GoTo(l000005b5)==>Register(R31, bv64)->Top
+%000005b8: Register(R0, bv64) := 0bv64==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+%0000060d: Register(R0, bv64) := ZeroExtend(32, Register(R1, bv64)[32:0])==>Register(R31, bv64)->Top
+%000004eb: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R0, bv64), 4040bv64), LittleEndian, 64)==>Register(R1, bv64)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+%00000606: GoTo(l000005b5_goto_l00000604, l000005b5_goto_l00000777)==>Register(R1, bv64)->Top<>LocalVar(ZF, bv1)->Top<>Register(R31, bv64)->Top
+Procedure sub_seven at 2180 with 2 blocks and 0 in and 1 out parameters==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%000005d1: Register(R2, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 56bv64), LittleEndian, 64)==>Register(R2, bv64)->Top<>Register(R1, bv64)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+Procedure main at 2216 with 9 blocks and 2 in and 2 out parameters==>Register(R1, bv64)->Top<>Register(R30, bv64)->Top<>Register(R29, bv64)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+%0000055d: Register(R3, bv64) := Register(R0, bv64)==>Register(R2, bv64)->Top<>Register(R3, bv64)->Top<>Register(R31, bv64)->Top
+%00000532: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R0, bv64), 4064bv64), LittleEndian, 64)==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+Block l00000604==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+Block l000005b5==>Register(R31, bv64)->Top
+%00000526: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 16bv64), Register(R1, bv64), LittleEndian, 64)==>Register(R31, bv64)->Top
+IndirectCall(Register(R30, bv64), None)==>Register(R31, bv64)->Top
+%000004f3: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), Register(R0, bv64), Register(R1, bv64)[32:0], LittleEndian, 32)==>Register(R31, bv64)->Top<>Register(R30, bv64)->Top
+%000005a1: Register(R30, bv64) := 2300bv64==>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+%00000564: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), Register(R3, bv64), LittleEndian, 64)==>Register(R2, bv64)->Top<>Register(R3, bv64)->Top<>Register(R0, bv64)->Top<>Register(R31, bv64)->Top
+Block sub_seven_basil_return==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+assume (bvcomp1(LocalVar(ZF, bv1), 1bv1) == 0bv1)None==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+%0000058d: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 32bv64), LittleEndian, 64)==>Register(R31, bv64)->Top
+%00000619: Register(R30, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 8bv64), LittleEndian, 64)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+GoTo(l000005a6)==>Register(R31, bv64)->Top
+%000005c3: Register(R0, bv64) := 65536bv64==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top<>Register(R1, bv64)->Top
+%000005de: LocalVar(#7, bv64) := bvnot64(Register(R3, bv64))==>LocalVar(#7, bv64)->Top<>Register(R31, bv64)->Top<>Register(R2, bv64)->Top<>Register(R1, bv64)->Top<>Register(R3, bv64)->Top
+%00000541: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R31, bv64), 56bv64), Register(R1, bv64), LittleEndian, 64)==>Register(R31, bv64)->Top
+GoTo(l00000604)==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+Block l00000777==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+%00000500: LocalVar(#6, bv64) := bvadd64(Register(R31, bv64), 18446744073709551552bv64)==>Register(R1, bv64)->Top<>LocalVar(#6, bv64)->Top<>Register(R0, bv64)->Top<>Register(R30, bv64)->Top<>Register(R29, bv64)->Top
+%000005b0: Register(R30, bv64) := 2308bv64==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top
+Block l000005b5_goto_l00000604==>Register(R1, bv64)->Top<>Register(R31, bv64)->Top<>LocalVar(ZF, bv1)->Top
+%00000577: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(Register(R2, bv64), 8bv64), Register(R1, bv64), LittleEndian, 64)==>Register(R31, bv64)->Top<>Register(R3, bv64)->Top<>Register(R2, bv64)->Top
+%000005e9: LocalVar(VF, bv1) := bvnot1(bvcomp65(SignExtend(1, LocalVar(#8, bv64)), bvadd65(bvadd65(SignExtend(1, Register(R2, bv64)), SignExtend(1, LocalVar(#7, bv64))), 1bv65)))==>Register(R1, bv64)->Top<>LocalVar(#7, bv64)->Top<>Register(R31, bv64)->Top<>Register(R2, bv64)->Top<>LocalVar(#8, bv64)->Top
+Block l000005b5_goto_l00000777==>LocalVar(ZF, bv1)->Top<>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+GoTo(sub_seven_basil_return)==>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%000004e4: Register(R0, bv64) := 65536bv64==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top<>Register(R30, bv64)->Top<>Register(R0, bv64)->Top
+%00000506: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), LocalVar(#6, bv64), Register(R29, bv64), LittleEndian, 64)==>LocalVar(#6, bv64)->Top<>Register(R30, bv64)->Top<>Register(R0, bv64)->Top<>Register(R1, bv64)->Top
+%000005fb: Register(R2, bv64) := LocalVar(#8, bv64)==>LocalVar(ZF, bv1)->Top<>Register(R1, bv64)->Top<>Register(R31, bv64)->Top
+%0000057e: Register(R0, bv64) := MemoryLoad(Memory(mem, 64, 8), bvadd64(Register(R3, bv64), 16bv64), LittleEndian, 64)==>Register(R0, bv64)->Top<>Register(R31, bv64)->Top<>Register(R2, bv64)->Top
+%000005be: Register(R1, bv64) := ZeroExtend(32, Register(R0, bv64)[32:0])==>Register(R1, bv64)->Top<>Register(R31, bv64)->Top
+%0000050c: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), bvadd64(LocalVar(#6, bv64), 8bv64), Register(R30, bv64), LittleEndian, 64)==>Register(R1, bv64)->Top<>LocalVar(#6, bv64)->Top<>Register(R0, bv64)->Top
+%000004cb: Register(R0, bv64) := 65536bv64==>Register(R0, bv64)->Top<>Register(R30, bv64)->Top<>Register(R31, bv64)->Top
+%000004df: Register(R1, bv64) := ZeroExtend(32, bvadd32(Register(R0, bv64)[32:0], 4294967289bv32))==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top<>Register(R30, bv64)->Top
+GoTo(l00000777)==>Register(R1, bv64)->Top<>Register(R31, bv64)->Top
+%000005f7: LocalVar(NF, bv1) := LocalVar(#8, bv64)[64:63]==>LocalVar(ZF, bv1)->Top<>Register(R1, bv64)->Top<>LocalVar(#8, bv64)->Top<>Register(R31, bv64)->Top
+%00000557: Register(R2, bv64) := bvadd64(Register(R31, bv64), 32bv64)==>Register(R31, bv64)->Top<>Register(R0, bv64)->Top<>Register(R2, bv64)->Top
+%000005ef: LocalVar(CF, bv1) := bvnot1(bvcomp65(ZeroExtend(1, LocalVar(#8, bv64)), bvadd65(bvadd65(ZeroExtend(1, Register(R2, bv64)), ZeroExtend(1, LocalVar(#7, bv64))), 1bv65)))==>Register(R1, bv64)->Top<>Register(R31, bv64)->Top<>LocalVar(#8, bv64)->Top
+%00000510: Register(R31, bv64) := LocalVar(#6, bv64)==>Register(R0, bv64)->Top<>Register(R1, bv64)->Top<>Register(R31, bv64)->Top
+%00000571: Memory(mem, 64, 8) := MemoryStore(Memory(mem, 64, 8), Register(R2, bv64), Register(R0, bv64), LittleEndian, 64)==>Register(R2, bv64)->Top<>Register(R3, bv64)->Top<>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+%00000789: IndirectCall(Register(R0, bv64), Some(l00000604))==>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+GoTo(main_basil_return)==>Register(R30, bv64)->Top
+%00000786: Register(R30, bv64) := 2356bv64==>Register(R0, bv64)->Top<>Register(R31, bv64)->Top<>Register(R1, bv64)->Top
+%000005b3: IndirectCall(Register(R0, bv64), Some(l000005b5))==>Register(R31, bv64)->Top

--- a/src/test/analysis/params/dump/param_analysis_results
+++ b/src/test/analysis/params/dump/param_analysis_results
@@ -1,0 +1,2 @@
+Procedure sub_seven at 2180 with 2 blocks and 0 in and 1 out parameters->
+Procedure main at 2216 with 9 blocks and 2 in and 2 out parameters->R1,R0,

--- a/src/test/scala/MemoryRegionAnalysisMiscTest.scala
+++ b/src/test/scala/MemoryRegionAnalysisMiscTest.scala
@@ -3,7 +3,7 @@ import org.scalatest.Inside.inside
 import org.scalatest.*
 import org.scalatest.funsuite.*
 import util.RunUtils
-import util.{BASILConfig, BoogieGeneratorConfig, BoogieMemoryAccessMode, ILLoadingConfig, StaticAnalysisConfig}
+import util.{BASILConfig, BoogieGeneratorConfig, BoogieMemoryAccessMode, ILLoadingConfig, StaticAnalysisConfig, BasilResult}
 
 import java.io.{File, OutputStream, PrintStream, PrintWriter}
 class MemoryRegionAnalysisMiscTest extends AnyFunSuite with OneInstancePerTest {
@@ -16,7 +16,7 @@ class MemoryRegionAnalysisMiscTest extends AnyFunSuite with OneInstancePerTest {
     var expected = ""
     var actual = ""
     var output: Map[CfgNode, LiftedElement[Set[MemoryRegion]]] = Map()
-    RunUtils.loadAndTranslate(
+    val results = RunUtils.loadAndTranslate(
       BASILConfig(
         loading = ILLoadingConfig(
           adtFile = examplesPath + s"$name/$name.adt",
@@ -38,7 +38,7 @@ class MemoryRegionAnalysisMiscTest extends AnyFunSuite with OneInstancePerTest {
         dumpFolder.mkdir()
       }
 
-      output = RunUtils.memoryRegionAnalysisResults
+      output = results.analysis.get.memoryRegionResult
       val outFile = new File(tempPath + s"$name")
       val pw = new PrintWriter(outFile, "UTF-8")
       output.foreach { case (k, v) =>

--- a/src/test/scala/ir/InterpreterTests.scala
+++ b/src/test/scala/ir/InterpreterTests.scala
@@ -6,7 +6,7 @@ import org.scalatest.BeforeAndAfter
 import specification.SpecGlobal
 import translating.BAPToIR
 import util.{LogLevel, Logger}
-import util.RunUtils.{loadBAP, loadReadELF}
+import util.IRLoading.{loadBAP, loadReadELF}
 import util.ILLoadingConfig
 
 class InterpreterTests extends AnyFunSuite with BeforeAndAfter {


### PR DESCRIPTION
Refactors runutils to more cleanly separate the loading, analysis, and translation phases. 

We now have 3 objects, `Loading` `IRTransform` `StaticAnalysis` which contain only methods and no state, and 3 case classes, `IRContext`, `StaticAnalysisContext` and `BasilResult` which hold the results from each phase. 

We might still want to break up the `StaticAnalysis.analyze` further in the future. 

