### PR TITLE
Tests use "./src/test/correct/" instead of examples

### DIFF
--- a/src/test/scala/LiveVarsAnalysisTests.scala
+++ b/src/test/scala/LiveVarsAnalysisTests.scala
@@ -322,7 +322,7 @@ class LiveVarsAnalysisTests extends AnyFunSuite, TestUtil {
     // checks function call blocks
     assert(analysisResults(blocks("lmain")) == Map(R29 -> TwoElementTop, R30 -> TwoElementTop, R31 -> TwoElementTop))
     assert(analysisResults(blocks("lget_two")) == Map(R30 -> TwoElementTop, R31 -> TwoElementTop))
-    assert(analysisResults(blocks("l00000538")) == Map(R0 -> TwoElementTop, R31 -> TwoElementTop)) // aftercall block
+    assert(analysisResults(blocks("l00000946")) == Map(R0 -> TwoElementTop, R31 -> TwoElementTop)) // aftercall block
     assert(analysisResults(blocks("main_basil_return")) == Map(R30 -> TwoElementTop))
   }
 
@@ -336,7 +336,7 @@ class LiveVarsAnalysisTests extends AnyFunSuite, TestUtil {
     // main has parameter, callee (zero) has return and no parameter
     assert(analysisResults(blocks("lmain")) == Map(R0 -> TwoElementTop, R29 -> TwoElementTop, R30 -> TwoElementTop, R31 -> TwoElementTop))
     assert(analysisResults(blocks("lzero")) == Map(R30 -> TwoElementTop, R31 -> TwoElementTop))
-    assert(analysisResults(blocks("l000003d5")) == Map(R0 -> TwoElementTop, R31 -> TwoElementTop)) // aftercall block
+    assert(analysisResults(blocks("l00000323")) == Map(R0 -> TwoElementTop, R31 -> TwoElementTop)) // aftercall block
     assert(analysisResults(blocks("zero_basil_return")) == Map(R0 -> TwoElementTop, R30 -> TwoElementTop, R31 -> TwoElementTop))
   }
 
@@ -347,8 +347,8 @@ class LiveVarsAnalysisTests extends AnyFunSuite, TestUtil {
 
     // main has no parameters, get_two has three and a return
     assert(analysisResults(blocks("lmain")) == Map(R29 -> TwoElementTop, R30 -> TwoElementTop, R31 -> TwoElementTop))
-    assert(analysisResults(blocks("l000004a1")) == Map(R0 -> TwoElementTop, R31 -> TwoElementTop)) // get_two aftercall
-    assert(analysisResults(blocks("l000004e5")) == Map(R31 -> TwoElementTop)) // printf aftercall
+    assert(analysisResults(blocks("l000003ec")) == Map(R0 -> TwoElementTop, R31 -> TwoElementTop)) // get_two aftercall
+    assert(analysisResults(blocks("l00000430")) == Map(R31 -> TwoElementTop)) // printf aftercall
     assert(analysisResults(blocks("main_basil_return")) == Map(R30 -> TwoElementTop))
     assert(analysisResults(blocks("lget_two")) == Map(R0 -> TwoElementTop, R1 -> TwoElementTop, R2 -> TwoElementTop, R30 -> TwoElementTop, R31 -> TwoElementTop))
     assert(analysisResults(blocks("get_two_basil_return")) == Map(R0 -> TwoElementTop,  R30 -> TwoElementTop, R31 -> TwoElementTop))
@@ -360,11 +360,11 @@ class LiveVarsAnalysisTests extends AnyFunSuite, TestUtil {
     val blocks = result.ir.program.blocks
 
     // block after branch
-    assert(analysisResults(blocks("l000003f2")) == Map(R30 -> TwoElementTop, R31 -> TwoElementTop))
+    assert(analysisResults(blocks("l00000342")) == Map(R30 -> TwoElementTop, R31 -> TwoElementTop))
     // branch blocks
-    assert(analysisResults(blocks("lmain_goto_l000003e0")) == Map(LocalVar("ZF", BitVecType(1)) -> TwoElementTop,
+    assert(analysisResults(blocks("lmain_goto_l00000330")) == Map(LocalVar("ZF", BitVecType(1)) -> TwoElementTop,
       R30 -> TwoElementTop, R31 -> TwoElementTop))
-    assert(analysisResults(blocks("lmain_goto_l0000056e")) == Map(LocalVar("ZF", BitVecType(1)) -> TwoElementTop,
+    assert(analysisResults(blocks("lmain_goto_l00000369")) == Map(LocalVar("ZF", BitVecType(1)) -> TwoElementTop,
       R30 -> TwoElementTop, R31 -> TwoElementTop))
   }
 }

--- a/src/test/scala/ParamAnalaysisTests.scala
+++ b/src/test/scala/ParamAnalaysisTests.scala
@@ -58,22 +58,6 @@ class ParamAnalaysisTests extends AnyFunSuite, TestUtil{
     assert(analysisResults(procs("plus_one")) == Set(R0))
   }
 
-  test("indirect_call_outparam") {
-    val result: BasilResult = runExample("indirect_call_outparam")
-    val analysisResults = result.analysis.get.paramResults
-    val procs = result.ir.program.procs
-
-    assert(analysisResults(procs("main")) == Set.empty)
-    assert(analysisResults(procs("get_call")) == Set(R0))
-  }
-
-  ignore("indirect_call_outparam_unresolved_call") {
-    val result: BasilResult = runExample("indirect_call_outparam")
-    val analysisResults = result.analysis.get.paramResults
-    val procs = result.ir.program.procs
-
-    assert(analysisResults(procs("seven")) == Set.empty) // not analysed due to unresolved call
-  }
 
   test("initialisation") {
     val result: BasilResult = runExample("initialisation")
@@ -89,5 +73,16 @@ class ParamAnalaysisTests extends AnyFunSuite, TestUtil{
     val procs = result.ir.program.procs
 
     assert(analysisResults(procs("main")) == Set(R0, R1))
+  }
+
+  ignore("unresolved_calls") {
+    val result: BasilResult = runExample("jumptable")
+    val analysisResults = result.analysis.get.paramResults
+    val procs = result.ir.program.procs
+
+    // not analysed due to unresolved call
+    assert(analysisResults(procs("add_two")) == Set.empty)
+    assert(analysisResults(procs("add_six")) == Set.empty)
+    assert(analysisResults(procs("sub_seven")) == Set.empty)
   }
 }

--- a/src/test/scala/test_util/TestUtil.scala
+++ b/src/test/scala/test_util/TestUtil.scala
@@ -25,12 +25,12 @@ trait TestUtil {
   }
 
 
-  def runExample(name: String): BasilResult = {
+  def runExample(name: String, path: String = correctPath, variation: String = "gcc/"): BasilResult = {
     RunUtils.loadAndTranslate(
       BASILConfig(
         loading = ILLoadingConfig(
-          inputFile = examplePath + s"/$name/$name.adt",
-          relfFile = examplePath + s"/$name/$name.relf",
+          adtFile = path + s"/$name/$variation$name.adt",
+          relfFile = path + s"/$name/$variation$name.relf",
           specFile = None,
           dumpIL = None,
           mainProcedureName = "main",


### PR DESCRIPTION
Addresses #189 and #179 review comments about tests using inputs from test folder instead of examples folder