### PR TITLE
replicate_bits support

### DIFF
--- a/src/main/scala/boogie/BExpr.scala
+++ b/src/main/scala/boogie/BExpr.scala
@@ -88,7 +88,6 @@ case class BVExtract(end: Int, start: Int, body: BExpr) extends BExpr {
 case class BVRepeat(repeats: Int, body: BExpr) extends BExpr {
   override def getType: BitVecBType = BitVecBType(bodySize * repeats)
 
-
   private def bodySize: Int = body.getType match {
     case bv: BitVecBType => bv.size
     case _ => throw new Exception("type mismatch, non bv expression: " + body + " in body of extract: " + this)

--- a/src/main/scala/translating/SemanticsLoader.scala
+++ b/src/main/scala/translating/SemanticsLoader.scala
@@ -296,6 +296,22 @@ class SemanticsLoader(parserMap: immutable.Map[String, Array[Array[StmtContext]]
       case "append_bits.0" =>
         resolveBinaryOp(BVCONCAT, function, 2, typeArgs, args, ctx.getText)
 
+      case "replicate_bits.0" =>
+        checkArgs(function, 2, 2, typeArgs.size, args.size, ctx.getText)
+        val oldSize = parseInt(typeArgs(0))
+        val replications = parseInt(typeArgs(1))
+        val arg0 = visitExpr(args(0))
+        val arg1 = parseInt(args(1))
+        val newSize = oldSize * replications
+        if (arg1 != replications) {
+          Exception(s"inconsistent size parameters in replicate_bits.0: ${ctx.getText}")
+        }
+        if (arg0.isDefined) {
+          Some(Repeat(replications, arg0.get))
+        } else {
+          None
+        }
+
       case "ZeroExtend.0" =>
         checkArgs(function, 2, 2, typeArgs.size, args.size, ctx.getText)
         val oldSize = parseInt(typeArgs(0))


### PR DESCRIPTION
Supports the 'replicate_bits' operation from ASLi. This does not show up much (due to deliberate attempts to avoid producing it?) but is produced for instructions like `ld1r` and it is trivial to support so we may as well.